### PR TITLE
[codex] 完善设置页布局与交互

### DIFF
--- a/static/app.css
+++ b/static/app.css
@@ -75,25 +75,52 @@
   .settings-backdrop { position:fixed; inset:0; z-index:20; display:none; align-items:center; justify-content:center; padding:20px; background:rgba(0,0,0,0.58); backdrop-filter:blur(10px); }
   .settings-backdrop.show { display:flex; }
   .settings-modal { width:min(560px, 100%); max-height:calc(100vh - 40px); display:flex; flex-direction:column; border:1px solid var(--hairline); border-radius:12px; background:var(--surface-elevated); box-shadow:0 24px 80px rgba(0,0,0,0.48), inset 0 1px 0 rgba(255,255,255,0.05); overflow:hidden; }
-  .settings-head { display:flex; align-items:center; justify-content:space-between; padding:18px 20px; border-bottom:1px solid var(--hairline); }
+  .settings-primary-modal { width:min(900px, 100%); height:min(760px, calc(100dvh - 40px)); max-height:calc(100dvh - 40px); border-color:rgba(255,255,255,0.095); background:#13131f; box-shadow:0 28px 90px rgba(4,4,12,0.62), inset 0 1px 0 rgba(255,255,255,0.055); }
+  .settings-head { display:flex; align-items:center; justify-content:space-between; gap:20px; padding:18px 20px; border-bottom:1px solid var(--hairline); }
+  .settings-primary-modal .settings-head { min-height:92px; padding:18px 22px 17px; background:linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0)); }
   .settings-head h2 { font-size:1rem; color:var(--text-strong); font-weight:700; }
+  .settings-primary-modal .settings-head h2 { margin-top:2px; font-size:1.18rem; letter-spacing:-0.025em; }
+  .settings-head p { margin-top:4px; color:var(--text-dim); font-size:0.74rem; line-height:1.45; }
+  .settings-kicker { color:var(--gold); font-size:0.64rem; font-weight:800; letter-spacing:0.12em; }
   .settings-close { width:36px; height:36px; flex:0 0 auto; border:1px solid transparent; border-radius:8px; background:transparent; color:var(--text-dim); cursor:pointer; font-size:1.15rem; line-height:1; display:grid; place-items:center; transition:all 0.16s ease; }
+  .settings-close svg { width:17px; height:17px; fill:none; stroke:currentColor; stroke-width:1.8; stroke-linecap:round; }
   .settings-close:hover { background:var(--control-bg-hover); border-color:var(--control-border); color:var(--text); }
   .settings-close:active { transform:scale(0.96); }
   .settings-close:focus-visible { outline:none; box-shadow:var(--focus-ring); }
-  .settings-tabs { flex:0 0 auto; display:flex; gap:6px; padding:12px 20px 0; background:var(--surface-elevated); overflow-x:auto; scrollbar-width:none; }
+  .settings-workspace { flex:1 1 auto; min-height:0; display:grid; grid-template-columns:190px minmax(0, 1fr); }
+  .settings-sidebar { min-width:0; padding:16px 12px; border-right:1px solid var(--hairline); background:rgba(7,7,16,0.24); }
+  .settings-tabs { display:flex; flex-direction:column; gap:5px; overflow:auto; scrollbar-width:none; }
   .settings-tabs::-webkit-scrollbar { display:none; }
-  .settings-tab { flex:1 0 0; min-width:max-content; min-height:var(--control-height); padding:9px 12px; border:1px solid var(--control-border); border-radius:8px; background:var(--control-bg); color:var(--control-muted); cursor:pointer; font-size:0.82rem; font-weight:700; line-height:1.2; transition:transform 0.16s ease, border-color 0.16s ease, background 0.16s ease, color 0.16s ease, box-shadow 0.16s ease; }
-  .settings-tab:hover { color:var(--text); border-color:rgba(232,184,48,0.28); background:var(--control-bg-hover); }
+  .settings-tab { position:relative; min-width:0; min-height:54px; padding:9px 12px 9px 15px; border:1px solid transparent; border-radius:9px; background:transparent; color:var(--control-muted); cursor:pointer; text-align:left; line-height:1.2; transition:transform 0.16s ease, border-color 0.16s ease, background 0.16s ease, color 0.16s ease, box-shadow 0.16s ease; }
+  .settings-tab::before { content:""; position:absolute; left:5px; top:12px; bottom:12px; width:2px; border-radius:99px; background:transparent; transition:background 0.16s ease, box-shadow 0.16s ease; }
+  .settings-tab span { display:block; color:inherit; font-size:0.8rem; font-weight:750; }
+  .settings-tab small { display:block; margin-top:4px; color:var(--text-dim); font-size:0.65rem; font-weight:500; line-height:1.25; }
+  .settings-tab:hover { color:var(--text); border-color:rgba(255,255,255,0.065); background:rgba(255,255,255,0.035); }
   .settings-tab:active { transform:translateY(1px); }
   .settings-tab:focus-visible { outline:none; box-shadow:var(--focus-ring); }
-  .settings-tab.active { background:linear-gradient(180deg, #f0c64a, var(--gold)); border-color:rgba(232,184,48,0.66); color:#111116; box-shadow:var(--shadow-control-strong); }
+  .settings-tab.active { border-color:rgba(232,184,48,0.17); background:rgba(232,184,48,0.075); color:#f5d777; box-shadow:inset 0 1px 0 rgba(255,255,255,0.025); }
+  .settings-tab.active::before { background:var(--gold); box-shadow:0 0 12px rgba(232,184,48,0.28); }
+  .settings-tab.active small { color:#b9ab83; }
+  .settings-tab.has-error span::after { content:""; display:inline-block; width:6px; height:6px; margin-left:7px; border-radius:50%; background:var(--up); box-shadow:0 0 8px rgba(224,85,106,0.35); vertical-align:1px; }
   .settings-body { flex:1 1 auto; min-height:0; overflow-y:auto; overscroll-behavior:contain; padding:6px 20px 18px; scrollbar-width:thin; scrollbar-color:rgba(232,184,48,0.55) rgba(255,255,255,0.05); }
+  .settings-primary-modal .settings-body { padding:22px 24px 28px; scroll-padding-top:22px; }
   .settings-body::-webkit-scrollbar { width:8px; }
   .settings-body::-webkit-scrollbar-track { background:rgba(255,255,255,0.04); border-radius:99px; }
   .settings-body::-webkit-scrollbar-thumb { background:rgba(232,184,48,0.45); border-radius:99px; }
   .settings-panel { display:none; }
   .settings-panel.active { display:block; }
+  .settings-panel-head { margin-bottom:18px; }
+  .settings-panel-head > span { display:block; margin-bottom:5px; color:var(--gold); font-size:0.64rem; font-weight:800; letter-spacing:0.1em; }
+  .settings-panel-head h3 { color:var(--text-strong); font-size:1.08rem; line-height:1.35; letter-spacing:-0.018em; text-wrap:balance; }
+  .settings-panel-head p { max-width:62ch; margin-top:6px; color:var(--text-dim); font-size:0.74rem; line-height:1.55; text-wrap:pretty; }
+  .setting-section { margin-top:14px; border:1px solid rgba(255,255,255,0.065); border-radius:12px; background:rgba(255,255,255,0.018); overflow:hidden; }
+  .setting-section:first-of-type { margin-top:0; }
+  .setting-section-head { padding:14px 16px 12px; border-bottom:1px solid var(--hairline); background:rgba(255,255,255,0.018); }
+  .setting-section-head h4 { color:var(--text); font-size:0.8rem; font-weight:750; line-height:1.35; }
+  .setting-section-head p { margin-top:4px; color:var(--text-dim); font-size:0.68rem; line-height:1.45; }
+  .setting-section-danger { border-color:rgba(224,85,106,0.24); background:rgba(224,85,106,0.025); }
+  .setting-section-danger .setting-section-head { background:rgba(224,85,106,0.045); }
+  .setting-section-danger .setting-section-head h4 { color:#f0a0ae; }
   .onboarding-backdrop { z-index:40; }
   .onboarding-modal { width:min(620px, 100%); }
   .onboarding-kicker { margin-bottom:4px; color:var(--gold); font-size:0.68rem; font-weight:700; letter-spacing:0.08em; }
@@ -115,10 +142,16 @@
   .onboarding-note, .onboarding-summary { margin-top:16px; padding:12px 14px; border:1px solid rgba(232,184,48,0.2); border-radius:10px; background:rgba(232,184,48,0.06); color:var(--text-dim); font-size:0.75rem; line-height:1.6; }
   .onboarding-foot { justify-content:space-between; }
   .onboarding-foot-actions { display:flex; gap:8px; }
-  .setting-row { display:flex; align-items:center; justify-content:space-between; gap:18px; padding:16px 0; border-bottom:1px solid var(--hairline); }
+  .setting-row { display:grid; grid-template-columns:minmax(0, 1fr) minmax(230px, 340px); align-items:center; gap:18px; padding:14px 16px; border-bottom:1px solid var(--hairline); }
   .setting-row:last-child { border-bottom:none; }
-  .setting-label { font-size:0.9rem; color:var(--text); margin-bottom:4px; }
-  .setting-desc { font-size:0.74rem; color:var(--text-dim); line-height:1.45; }
+  .setting-row-top { align-items:start; }
+  .setting-row > :not(:first-child) { justify-self:end; }
+  .setting-label { margin-bottom:4px; color:var(--text); font-size:0.8rem; font-weight:650; line-height:1.4; }
+  .setting-desc { max-width:54ch; color:var(--text-dim); font-size:0.69rem; line-height:1.48; text-wrap:pretty; }
+  .setting-status { display:block; margin-top:7px; padding:7px 9px; border-left:2px solid rgba(232,184,48,0.52); border-radius:0 7px 7px 0; background:rgba(232,184,48,0.055); color:#bdb6a2; line-height:1.45; overflow-wrap:anywhere; }
+  .setting-status[data-state="ok"] { border-left-color:rgba(55,211,139,0.65); background:rgba(55,211,139,0.055); color:#8dd8b5; }
+  .setting-status[data-state="error"] { border-left-color:rgba(224,85,106,0.7); background:rgba(224,85,106,0.06); color:#eea3af; }
+  .setting-status-wide { width:100%; max-width:340px; margin-top:0; }
   .export-dir-check { display:block; overflow-wrap:anywhere; }
   .export-dir-check.ok { color:var(--down); }
   .export-dir-check.fail { color:var(--up); }
@@ -131,13 +164,23 @@
   .switch input:checked + .slider { background:rgba(232,184,48,0.22); border-color:rgba(232,184,48,0.55); }
   .switch input:checked + .slider::before { transform:translateX(22px); background:var(--gold); }
   .switch input:focus-visible + .slider { box-shadow:var(--focus-ring); }
-  .settings-select { min-width:170px; min-height:38px; padding:8px 10px; border-radius:8px; border:1px solid var(--control-border); background:#101020; color:var(--text); outline:none; transition:border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease; }
-  .settings-input { min-width:230px; width:min(320px, 45vw); min-height:38px; padding:8px 10px; border-radius:8px; border:1px solid var(--control-border); background:#101020; color:var(--text); outline:none; transition:border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease; }
-  .settings-textarea { min-width:230px; width:min(360px, 48vw); min-height:92px; padding:9px 10px; border-radius:8px; border:1px solid var(--control-border); background:#101020; color:var(--text); outline:none; resize:vertical; line-height:1.5; }
+  .settings-select { min-width:190px; width:min(100%, 340px); min-height:38px; padding:8px 10px; border-radius:8px; border:1px solid var(--control-border); background:#101020; color:var(--text); outline:none; transition:border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease; }
+  .settings-input { min-width:0; width:100%; max-width:340px; min-height:38px; padding:8px 10px; border-radius:8px; border:1px solid var(--control-border); background:#101020; color:var(--text); outline:none; transition:border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease; }
+  .settings-textarea { min-width:0; width:100%; max-width:340px; min-height:100px; padding:9px 10px; border-radius:8px; border:1px solid var(--control-border); background:#101020; color:var(--text); outline:none; resize:vertical; line-height:1.5; }
+  .settings-textarea-large { min-height:180px; }
   .settings-input:focus, .settings-select:focus, .settings-textarea:focus { border-color:var(--control-border-strong); background:#121225; box-shadow:var(--focus-ring); }
-  .settings-input.smtp-port { max-width:100px; }
-  .settings-stack { display:flex; align-items:center; justify-content:flex-end; gap:8px; flex-wrap:wrap; }
-  .settings-stack .settings-select { min-width:190px; }
+  .settings-input.invalid, .settings-select.invalid, .settings-textarea.invalid, .inline-check.invalid { border-color:rgba(224,85,106,0.72); box-shadow:0 0 0 3px rgba(224,85,106,0.09); }
+  .settings-input.smtp-port { width:116px; max-width:116px; }
+  .settings-stack { width:100%; max-width:340px; display:flex; align-items:center; justify-content:flex-end; gap:8px; flex-wrap:wrap; }
+  .settings-stack .settings-select { min-width:0; flex:1 1 190px; }
+  .settings-stack .settings-input { flex:1 1 128px; }
+  .settings-stack-column { flex-direction:column; align-items:stretch; }
+  .settings-stack-column > .settings-stack { max-width:none; }
+  .settings-secret-control { align-items:stretch; }
+  .settings-secret-control .settings-input { flex-basis:100%; }
+  .settings-time-separator { color:var(--text-dim); font-size:0.7rem; }
+  .setting-action-status { align-items:flex-end; flex-direction:column; }
+  .setting-field-error { grid-column:2; width:100%; margin-top:-8px; color:#f2a0ae; font-size:0.68rem; line-height:1.4; text-align:right; }
   .data-archive-preview { flex:1 1 100%; max-width:560px; color:var(--text-dim); font-size:0.68rem; line-height:1.55; overflow-wrap:anywhere; }
   .data-archive-preview-ok { color:var(--down); }
   .data-archive-preview-error { color:var(--up); }
@@ -162,7 +205,17 @@
   .risk-provider-row.hidden { display:none; }
   .hidden-control { display:none; }
   .platform-hidden { display:none !important; }
-  .settings-foot { flex:0 0 auto; display:flex; justify-content:flex-end; gap:10px; padding:16px 20px 20px; border-top:1px solid var(--hairline); background:var(--surface-elevated); }
+  .settings-unsaved { flex:0 0 auto; display:flex; align-items:center; justify-content:space-between; gap:16px; padding:12px 20px; border-top:1px solid rgba(224,85,106,0.25); background:rgba(224,85,106,0.07); }
+  .settings-unsaved[hidden] { display:none; }
+  .settings-unsaved strong, .settings-unsaved span { display:block; }
+  .settings-unsaved strong { color:#f0c5cc; font-size:0.76rem; }
+  .settings-unsaved span { margin-top:3px; color:var(--text-dim); font-size:0.68rem; }
+  .settings-unsaved-actions { display:flex; gap:8px; }
+  .settings-foot { flex:0 0 auto; display:flex; align-items:center; justify-content:space-between; gap:16px; padding:13px 20px 15px; border-top:1px solid var(--hairline); background:#151521; }
+  .settings-foot-copy { min-width:0; flex:1 1 auto; }
+  .settings-foot-actions { flex:0 0 auto; display:flex; gap:9px; }
+  .settings-dirty-state { display:block; color:var(--text-dim); font-size:0.68rem; line-height:1.3; }
+  .settings-dirty-state.changed { color:var(--gold); }
   .settings-save, .settings-cancel, .update-install, .dialog-danger, .btn-set, .btn-clear, .btn-clear-sm, .price-retry, .risk-open { min-height:var(--control-height); display:inline-flex; align-items:center; justify-content:center; gap:6px; max-width:100%; border-radius:8px; cursor:pointer; font-weight:700; line-height:1.2; white-space:nowrap; user-select:none; overflow:hidden; text-overflow:ellipsis; transition:transform 0.16s ease, border-color 0.16s ease, background 0.16s ease, color 0.16s ease, box-shadow 0.16s ease, opacity 0.16s ease, filter 0.16s ease; }
   .settings-save, .update-install, .btn-set { border:1px solid rgba(232,184,48,0.66); background:linear-gradient(180deg, #f2ca58, #dca928); color:#111116; box-shadow:var(--shadow-control-strong); }
   .settings-save:hover, .update-install:hover, .btn-set:hover { filter:brightness(1.045); transform:translateY(-1px); box-shadow:0 12px 26px rgba(232,184,48,0.24), inset 0 1px 0 rgba(255,255,255,0.30); }
@@ -174,7 +227,10 @@
   .settings-cancel:active, .btn-clear:active, .btn-clear-sm:active { transform:translateY(0) scale(0.98); }
   .settings-save { padding:9px 20px; }
   .settings-cancel { padding:9px 16px; }
-  .settings-message { min-height:18px; padding:0 20px 14px; color:var(--warn); font-size:0.78rem; }
+  .settings-message { min-height:0; margin-top:3px; color:var(--warn); font-size:0.7rem; line-height:1.4; }
+  .settings-message:empty { display:none; }
+  .settings-message[data-state="ok"] { color:var(--down); }
+  .settings-message[data-state="error"] { color:#f2a0ae; }
   .setting-section-divider { height:1px; background:var(--hairline); margin:6px 0 12px; }
   .setting-section-title { font-size:0.82rem; color:var(--gold); font-weight:700; margin-bottom:10px; letter-spacing:0.04em; }
   .test-email-status { font-size:0.72rem; margin-left:8px; font-weight:500; }
@@ -189,7 +245,8 @@
   .update-progress span { display:block; height:100%; width:0%; background:linear-gradient(90deg, #f0c64a, var(--gold)); transition:width 0.18s ease; }
   .update-install { padding:9px 20px; }
   .update-install:disabled, .btn-set:disabled, .settings-save:disabled, .price-retry:disabled, .risk-open:disabled { opacity:0.48; cursor:not-allowed; transform:none; box-shadow:none; filter:none; }
-  .ops-update-card { align-items:flex-end; max-width:min(520px, 100%); }
+  .settings-primary-modal .settings-save:disabled { border-color:var(--control-border); background:#292831; color:#777684; opacity:1; }
+  .ops-update-card { align-items:stretch; max-width:min(520px, 100%); }
   .ops-update-copy { min-width:180px; max-width:100%; flex:1 1 220px; text-align:left; }
   .ops-update-status { color:var(--text); font-size:0.8rem; line-height:1.35; white-space:normal; overflow-wrap:anywhere; }
   .ops-update-status[data-state="error"] { color:var(--up); }
@@ -1016,7 +1073,9 @@
     .threshold-card { overflow:visible; }
     .threshold-card .card-inner { height:auto; overflow:visible; }
     .source-health-list { max-height:108px; }
-    .settings-modal.update-modal, .settings-modal.risk-modal, .settings-modal.history-modal { width:calc(100vw - 24px); }
+    .settings-primary-modal, .settings-modal.update-modal, .settings-modal.risk-modal, .settings-modal.history-modal { width:calc(100vw - 24px); }
+    .settings-workspace { grid-template-columns:174px minmax(0, 1fr); }
+    .settings-primary-modal .settings-body { padding-left:20px; padding-right:20px; }
   }
 
   @media (max-width:720px) {
@@ -1059,6 +1118,27 @@
     .onboarding-field .settings-select { width:100%; }
     .portfolio-performance-metrics, .portfolio-effectiveness-grid { grid-template-columns:repeat(2, minmax(0, 1fr)); }
     .alert-center-form-grid { grid-template-columns:repeat(2, minmax(0, 1fr)); }
+    .settings-primary-modal { height:calc(100dvh - 24px); max-height:calc(100dvh - 24px); }
+    .settings-primary-modal .settings-head { min-height:auto; padding:14px 16px 13px; }
+    .settings-head p { display:none; }
+    .settings-workspace { display:grid; grid-template-columns:132px minmax(0, 1fr); }
+    .settings-sidebar { min-width:0; padding:10px 8px; border-right:1px solid var(--hairline); border-bottom:none; }
+    .settings-tabs { flex-direction:column; gap:4px; overflow-x:hidden; overflow-y:auto; }
+    .settings-tab { min-height:46px; padding:8px 8px 8px 13px; }
+    .settings-tab::before { left:4px; top:10px; bottom:10px; }
+    .settings-tab small { display:none; }
+    .settings-primary-modal .settings-body { padding:18px 14px 24px; }
+    .setting-row { grid-template-columns:1fr; align-items:stretch; gap:10px; padding:13px 14px; }
+    .setting-row > :not(:first-child) { justify-self:stretch; }
+    .setting-field-error { grid-column:1; margin-top:-5px; text-align:left; }
+    .settings-input { min-width:0; width:100%; max-width:none; }
+    .settings-input.smtp-port { width:100%; max-width:none; }
+    .settings-textarea { min-width:0; width:100%; max-width:none; }
+    .settings-select { min-width:0; width:100%; max-width:none; }
+    .settings-stack { width:100%; max-width:none; justify-content:flex-start; }
+    .settings-stack .settings-input { flex:1 1 128px; }
+    .setting-action-status { align-items:stretch; }
+    .setting-status-wide { max-width:none; }
   }
 
   @media (max-width:500px) {
@@ -1143,19 +1223,21 @@
     .portfolio-review-point { grid-template-columns:1fr; }
     .portfolio-review-metrics { grid-template-columns:1fr 1fr; }
     .settings-backdrop { padding:10px; }
-    .settings-modal { max-height:calc(100vh - 20px); }
-    .settings-tabs { padding:10px 14px 0; }
-    .settings-tab { flex:0 0 auto; min-width:86px; }
-    .settings-body { padding:4px 14px 14px; }
-    .setting-row { flex-direction:column; align-items:stretch; gap:10px; padding:14px 0; }
-    .settings-input { min-width:0; width:100%; }
-    .settings-input.smtp-port { max-width:none; }
-    .settings-textarea { min-width:0; width:100%; }
-    .settings-select { min-width:0; width:100%; }
-    .settings-stack { width:100%; justify-content:flex-start; }
-    .settings-stack .settings-input { flex:1 1 128px; }
-    .settings-foot { flex-wrap:wrap; }
-    .settings-foot button { flex:1 1 132px; min-width:0; }
+    .settings-modal { max-height:calc(100dvh - 20px); }
+    .settings-primary-modal { width:100%; height:calc(100dvh - 20px); }
+    .settings-workspace { grid-template-columns:106px minmax(0, 1fr); }
+    .settings-sidebar { padding:8px 6px; }
+    .settings-tab { min-height:42px; padding:8px 6px 8px 12px; }
+    .settings-tab span { font-size:0.72rem; }
+    .settings-tab::before { left:3px; top:9px; bottom:9px; }
+    .settings-primary-modal .settings-body { padding:16px 10px 22px; }
+    .settings-panel-head { padding:0 4px; }
+    .settings-unsaved { align-items:stretch; flex-direction:column; }
+    .settings-unsaved-actions { width:100%; }
+    .settings-unsaved-actions button { flex:1 1 0; }
+    .settings-foot { align-items:stretch; flex-direction:column; gap:9px; padding:11px 14px 13px; }
+    .settings-foot-actions { width:100%; }
+    .settings-foot-actions button { flex:1 1 0; min-width:0; }
     .mode-btn { min-height:40px; padding-left:6px; padding-right:6px; }
     .mode-btn small { display:block; margin-top:2px; font-size:0.68rem; }
     .chart-header { gap:8px; }

--- a/static/app.js
+++ b/static/app.js
@@ -196,6 +196,35 @@ let appSettings = {
 let pendingSettingsSave = false;
 let settingsSaveFailed = false;
 let settingsSaveTimer = null;
+const SETTINGS_TABS = ['general', 'email', 'webhook', 'digest', 'risk', 'ops'];
+const SETTINGS_TAB_STORAGE_KEY = 'goldmonitor.settings.activeTab';
+const SETTINGS_TAB_LABELS = {
+  general: '通用设置',
+  email: '邮件通知',
+  webhook: 'Webhook',
+  digest: '摘要通知',
+  risk: '风险分析',
+  ops: '运维与数据',
+};
+const SETTINGS_FIELD_IDS = [
+  'setStartup', 'setStartupTray', 'setFloatingPrice', 'setFloatingDisplayMode',
+  'setFloatingPreset', 'setFloatingOpacity', 'setFloatingSnapEdge', 'setFloatingAlwaysOnTop',
+  'setCloseBehavior', 'setAlertSound', 'setAlertDialog', 'setAlertCooldownMinutes',
+  'setAlertQuietStart', 'setAlertQuietEnd', 'setSmtpServer', 'setSmtpPort',
+  'setSmtpEncryption', 'setSmtpSender', 'setSmtpPassword', 'clearSmtpPassword',
+  'setSmtpRecipient', 'setEmailSubjectTemplate', 'setEmailBodyTemplate', 'setWebhookEnabled',
+  'setWebhookUrl', 'setWebhookWarning', 'setWebhookCritical', 'setWebhookVolatility',
+  'setDailyDigestEnabled', 'setDailyDigestTime', 'setDailyDigestEmail', 'setDailyDigestWebhook',
+  'setRiskAssistantEnabled', 'setRiskAssistantProvider', 'setRiskAssistantDepth',
+  'setDeepseekBaseUrl', 'setDeepseekModel', 'setDeepseekApiKey', 'clearDeepseekApiKey',
+  'setOpenaiCompatibleBaseUrl', 'setOpenaiCompatibleModel', 'setOpenaiCompatibleApiKey',
+  'clearOpenaiCompatibleApiKey', 'setRiskMaxTokens', 'setRiskCooldownSeconds',
+  'setRiskCacheMinutes', 'setExportDir',
+];
+let settingsInitialSnapshot = '';
+let settingsDirty = false;
+let settingsLastFocused = null;
+let activeSettingsTab = 'general';
 let pendingUpdateInfo = null;
 let pendingConfigImportPayload = null;
 let pendingConfigImportPreview = null;
@@ -861,13 +890,14 @@ socket.on('settings_updated', data => {
     appSettings = Object.assign({}, appSettings, data || {});
     if (shouldClearProfileMatch) clearCurrentAlertProfileMatch();
     pendingSettingsSave = false;
+    setSettingsSaving(false);
     return;
   }
   applySettings(data || {});
   if (shouldClearProfileMatch) clearCurrentAlertProfileMatch();
-  document.getElementById('settingsMessage').textContent = '';
-  if (pendingSettingsSave) closeSettings();
   pendingSettingsSave = false;
+  resetSettingsDirtySnapshot();
+  showSettingsMessage('设置已保存并生效。', 'ok');
 });
 
 socket.on('settings_error', data => {
@@ -877,7 +907,8 @@ socket.on('settings_error', data => {
   }
   pendingSettingsSave = false;
   settingsSaveFailed = true;
-  document.getElementById('settingsMessage').textContent = data.message || '设置保存失败';
+  setSettingsDirty(true);
+  showSettingsMessage(data.message || '设置保存失败。', 'error');
   if (data && data.export_dir_check) renderExportDirStatus(data.export_dir_check);
 });
 
@@ -1016,12 +1047,14 @@ socket.on('open_risk_analysis', data => {
 socket.on('risk_model_options_updated', data => {
   if (!data || data.provider !== 'deepseek') return;
   deepseekModelOptions = Array.isArray(data.models) && data.models.length ? data.models : deepseekModelOptions;
-  renderDeepseekModelOptions(appSettings.deepseek_model || 'deepseek-v4-pro');
+  const currentModel = document.getElementById('setDeepseekModel').value || appSettings.deepseek_model || 'deepseek-v4-pro';
+  renderDeepseekModelOptions(currentModel);
   const status = document.getElementById('deepseekModelStatus');
   if (status) {
     status.textContent = data.error
       ? data.error + ' 当前显示兜底模型。'
       : '模型列表已更新，来源：' + (data.source === 'api' ? '接口' : '兜底列表') + '。';
+    status.dataset.state = data.error ? 'error' : 'ok';
   }
 });
 
@@ -2453,6 +2486,7 @@ function configureSecretClear(inputId, statusId, buttonId, configured, statusTex
   if (!input || !status || !button) return;
   input.checked = false;
   status.textContent = statusText;
+  status.dataset.state = configured ? 'ok' : '';
   button.disabled = !configured;
   button.textContent = configured ? readyLabel : emptyLabel;
   button.classList.remove('marked');
@@ -2468,13 +2502,17 @@ function toggleSecretClear(inputId, statusId, buttonId, selectedStatus) {
   input.checked = !input.checked;
   if (input.checked) {
     status.textContent = selectedStatus;
+    status.dataset.state = 'error';
     button.textContent = '取消删除';
     button.classList.add('marked');
+    updateSettingsDirtyState();
     return;
   }
   status.textContent = button.dataset.defaultStatus || '';
+  status.dataset.state = button.disabled ? '' : 'ok';
   button.textContent = button.dataset.defaultLabel || '删除已保存密钥';
   button.classList.remove('marked');
+  updateSettingsDirtyState();
 }
 
 // ========== 设置 ==========
@@ -2531,7 +2569,10 @@ function setDailyDigestStatus(message, ok) {
   const status = document.getElementById('dailyDigestStatus');
   if (!status) return;
   status.textContent = message || '';
-  status.className = 'test-email-status' + (ok === true ? ' ok' : ok === false ? ' fail' : '');
+  status.className = 'setting-status setting-status-wide';
+  if (ok === true) status.dataset.state = 'ok';
+  else if (ok === false) status.dataset.state = 'error';
+  else delete status.dataset.state;
 }
 
 function applyDailyDigestStatus(data) {
@@ -2720,9 +2761,11 @@ function renderExportDirStatus(check, fallbackText) {
   const data = check && typeof check === 'object' ? check : null;
   if (!data || !data.status) {
     status.textContent = fallbackText || '留空使用默认导出目录。';
+    delete status.dataset.state;
     return;
   }
   const statusClass = data.ok ? 'ok' : 'fail';
+  status.dataset.state = data.ok ? 'ok' : 'error';
   const actions = Array.isArray(data.actions) ? data.actions.map(exportDirActionButton).filter(Boolean) : [];
   status.innerHTML = [
     '<span class="export-dir-check ' + statusClass + '">' + escapeHtml(data.message || fallbackText || '') + '</span>',
@@ -2731,8 +2774,7 @@ function renderExportDirStatus(check, fallbackText) {
 }
 
 function clearSettingsMessage() {
-  const message = document.getElementById('settingsMessage');
-  if (message) message.textContent = '';
+  showSettingsMessage('', '');
 }
 
 function resetExportDirField() {
@@ -2741,6 +2783,7 @@ function resetExportDirField() {
   input.value = '';
   clearSettingsMessage();
   renderExportDirStatus(null, '保存后将使用默认导出目录：' + (appSettings.export_dir_default || appSettings.export_dir_effective || '未记录'));
+  updateSettingsDirtyState();
 }
 
 function useDefaultExportDirFromError() {
@@ -2776,6 +2819,7 @@ function chooseExportDir() {
       const savedMessage = message + '，保存后生效。';
       if (status) status.textContent = savedMessage;
       setOpsStatus('已选择导出目录，保存后生效。', true);
+      updateSettingsDirtyState();
     })
     .catch(() => {
       const message = '无法打开系统目录选择器，请手动输入导出目录。';
@@ -2806,7 +2850,10 @@ function updateRiskProviderFields() {
 
 function refreshRiskModels() {
   const status = document.getElementById('deepseekModelStatus');
-  if (status) status.textContent = '正在获取模型列表...';
+  if (status) {
+    status.textContent = '正在获取模型列表...';
+    delete status.dataset.state;
+  }
   socket.emit('get_risk_model_options', { provider: 'deepseek' });
 }
 
@@ -2819,26 +2866,271 @@ function testRiskModel() {
   socket.emit('test_risk_model');
 }
 
-function switchSettingsTab(tab) {
-  const tabs = ['general', 'email', 'webhook', 'digest', 'risk', 'ops'];
-  tabs.forEach(name => {
-    const active = tab === name;
-    const suffix = name.charAt(0).toUpperCase() + name.slice(1);
-    document.getElementById('settingsTab' + suffix).classList.toggle('active', active);
-    document.getElementById('settingsTab' + suffix).setAttribute('aria-selected', String(active));
-    document.getElementById('settingsPanel' + suffix).classList.toggle('active', active);
+function settingsFieldElements() {
+  return SETTINGS_FIELD_IDS.map(id => document.getElementById(id)).filter(Boolean);
+}
+
+function captureSettingsSnapshot() {
+  const snapshot = {};
+  settingsFieldElements().forEach(element => {
+    snapshot[element.id] = element.type === 'checkbox' ? !!element.checked : element.value;
   });
+  return JSON.stringify(snapshot);
+}
+
+function showSettingsMessage(message, state) {
+  const element = document.getElementById('settingsMessage');
+  if (!element) return;
+  element.textContent = message || '';
+  if (state) element.dataset.state = state;
+  else delete element.dataset.state;
+}
+
+function setSettingsSaving(saving) {
+  const button = document.getElementById('settingsSaveButton');
+  if (!button) return;
+  button.textContent = saving ? '正在保存' : '保存更改';
+  button.disabled = !!saving || !settingsDirty;
+}
+
+function setSettingsDirty(dirty) {
+  settingsDirty = !!dirty;
+  const state = document.getElementById('settingsDirtyState');
+  if (state) {
+    state.textContent = settingsDirty ? '有未保存的更改' : '所有更改已保存';
+    state.classList.toggle('changed', settingsDirty);
+  }
+  setSettingsSaving(pendingSettingsSave);
+}
+
+function updateSettingsDirtyState() {
+  if (!settingsInitialSnapshot) return;
+  setSettingsDirty(captureSettingsSnapshot() !== settingsInitialSnapshot);
+}
+
+function resetSettingsDirtySnapshot() {
+  settingsInitialSnapshot = captureSettingsSnapshot();
+  setSettingsDirty(false);
+  hideSettingsDiscardPrompt();
+}
+
+function readStoredSettingsTab() {
+  try {
+    const stored = window.localStorage.getItem(SETTINGS_TAB_STORAGE_KEY) || '';
+    return SETTINGS_TABS.includes(stored) ? stored : 'general';
+  } catch (_error) {
+    return 'general';
+  }
+}
+
+function storeSettingsTab(tab) {
+  try {
+    window.localStorage.setItem(SETTINGS_TAB_STORAGE_KEY, tab);
+  } catch (_error) {
+    // 本机浏览器禁用存储时，仅在当前会话中保留分页。
+  }
+}
+
+function settingsTabForElement(element) {
+  const panel = element && element.closest ? element.closest('[data-settings-panel]') : null;
+  return panel ? panel.dataset.settingsPanel : 'general';
+}
+
+function clearSettingsValidation() {
+  const modal = document.querySelector('.settings-primary-modal');
+  if (!modal) return;
+  modal.querySelectorAll('.invalid').forEach(element => element.classList.remove('invalid'));
+  modal.querySelectorAll('[aria-invalid="true"]').forEach(element => {
+    element.removeAttribute('aria-invalid');
+    const describedBy = element.getAttribute('aria-describedby') || '';
+    if (describedBy.endsWith('Error')) element.removeAttribute('aria-describedby');
+  });
+  modal.querySelectorAll('.setting-field-error').forEach(element => element.remove());
+  modal.querySelectorAll('.settings-tab.has-error').forEach(element => element.classList.remove('has-error'));
+}
+
+function clearSettingsFieldError(element) {
+  if (!element) return;
+  element.classList.remove('invalid');
+  const inlineCheck = element.closest('.inline-check');
+  if (inlineCheck) inlineCheck.classList.remove('invalid');
+  element.removeAttribute('aria-invalid');
+  const error = document.getElementById(element.id + 'Error');
+  if (error) error.remove();
+  const tab = settingsTabForElement(element);
+  const panel = document.querySelector('[data-settings-panel="' + tab + '"]');
+  if (panel && !panel.querySelector('.setting-field-error')) {
+    const tabButton = document.querySelector('[data-settings-tab="' + tab + '"]');
+    if (tabButton) tabButton.classList.remove('has-error');
+  }
+}
+
+function renderSettingsValidation(errors) {
+  clearSettingsValidation();
+  errors.forEach(error => {
+    const element = document.getElementById(error.id);
+    if (!element) return;
+    const highlight = element.closest('.inline-check') || element;
+    highlight.classList.add('invalid');
+    element.setAttribute('aria-invalid', 'true');
+    const row = element.closest('.setting-row');
+    if (row && !document.getElementById(error.id + 'Error')) {
+      const note = document.createElement('div');
+      note.className = 'setting-field-error';
+      note.id = error.id + 'Error';
+      note.textContent = error.message;
+      row.appendChild(note);
+      element.setAttribute('aria-describedby', note.id);
+    }
+    const tabButton = document.querySelector('[data-settings-tab="' + error.tab + '"]');
+    if (tabButton) tabButton.classList.add('has-error');
+  });
+}
+
+function validateSettings() {
+  const errors = [];
+  const add = (id, message) => {
+    const element = document.getElementById(id);
+    if (!element) return;
+    errors.push({ id, message, tab: settingsTabForElement(element) });
+  };
+  const validateNumber = (id, label, min, max) => {
+    const element = document.getElementById(id);
+    if (!element || element.value.trim() === '') return;
+    const value = Number(element.value);
+    if (!Number.isFinite(value) || value < min || value > max) add(id, label + '应在 ' + min + ' 到 ' + max + ' 之间。');
+  };
+  const validateTypedValue = (id, message) => {
+    const element = document.getElementById(id);
+    if (element && element.value.trim() && !element.validity.valid) add(id, message);
+  };
+
+  validateNumber('setFloatingOpacity', '悬浮条透明度', 50, 100);
+  validateNumber('setAlertCooldownMinutes', '提醒冷却时间', 0, 240);
+  validateNumber('setSmtpPort', 'SMTP 端口', 1, 65535);
+  validateNumber('setRiskMaxTokens', '单次输出上限', 300, 4000);
+  validateNumber('setRiskCooldownSeconds', '分析冷却时间', 0, 300);
+  validateNumber('setRiskCacheMinutes', '重复分析缓存', 0, 60);
+  validateTypedValue('setSmtpSender', '发件邮箱格式不正确。');
+  validateTypedValue('setSmtpRecipient', '收件邮箱格式不正确。');
+  validateTypedValue('setWebhookUrl', 'Webhook 地址格式不正确。');
+  validateTypedValue('setDeepseekBaseUrl', 'DeepSeek API 地址格式不正确。');
+  validateTypedValue('setOpenaiCompatibleBaseUrl', '兼容接口地址格式不正确。');
+
+  const quietStart = document.getElementById('setAlertQuietStart').value;
+  const quietEnd = document.getElementById('setAlertQuietEnd').value;
+  if (!!quietStart !== !!quietEnd) add(quietStart ? 'setAlertQuietEnd' : 'setAlertQuietStart', '静默时段需要同时填写开始和结束时间。');
+
+  if (document.getElementById('setWebhookEnabled').checked) {
+    const webhookUrl = document.getElementById('setWebhookUrl').value.trim();
+    if (!webhookUrl) add('setWebhookUrl', '启用 Webhook 前需要填写接收地址。');
+    else if (!webhookUrl.toLowerCase().startsWith('https://')) add('setWebhookUrl', 'Webhook 地址必须使用 HTTPS。');
+  }
+
+  if (document.getElementById('setDailyDigestEnabled').checked) {
+    if (!document.getElementById('setDailyDigestTime').value) add('setDailyDigestTime', '启用每日摘要前需要设置发送时间。');
+    if (!document.getElementById('setDailyDigestEmail').checked && !document.getElementById('setDailyDigestWebhook').checked) {
+      add('setDailyDigestEmail', '启用每日摘要前至少选择一个发送渠道。');
+    }
+  }
+
+  if (document.getElementById('setRiskAssistantEnabled').checked) {
+    const provider = document.getElementById('setRiskAssistantProvider').value;
+    if (provider === 'deepseek') {
+      if (!document.getElementById('setDeepseekBaseUrl').value.trim()) add('setDeepseekBaseUrl', '需要填写 DeepSeek API 地址。');
+      if (!document.getElementById('setDeepseekModel').value) add('setDeepseekModel', '需要选择 DeepSeek 模型。');
+    } else {
+      if (!document.getElementById('setOpenaiCompatibleBaseUrl').value.trim()) add('setOpenaiCompatibleBaseUrl', '需要填写兼容接口地址。');
+      if (!document.getElementById('setOpenaiCompatibleModel').value.trim()) add('setOpenaiCompatibleModel', '需要填写兼容模型名称。');
+    }
+  }
+
+  renderSettingsValidation(errors);
+  if (!errors.length) return true;
+  const first = errors[0];
+  switchSettingsTab(first.tab);
+  showSettingsMessage(
+    SETTINGS_TAB_LABELS[first.tab] + '有 ' + errors.filter(error => error.tab === first.tab).length + ' 项需要处理：' + first.message,
+    'error'
+  );
+  window.requestAnimationFrame(() => {
+    const element = document.getElementById(first.id);
+    if (element) element.focus();
+  });
+  return false;
+}
+
+function handleSettingsFieldChange(event) {
+  const target = event.target;
+  if (!target || !SETTINGS_FIELD_IDS.includes(target.id)) return;
+  clearSettingsFieldError(target);
+  if (target.id === 'setDailyDigestEmail' || target.id === 'setDailyDigestWebhook') {
+    clearSettingsFieldError(document.getElementById('setDailyDigestEmail'));
+  }
+  if (target.id === 'setAlertQuietStart' || target.id === 'setAlertQuietEnd') {
+    clearSettingsFieldError(document.getElementById('setAlertQuietStart'));
+    clearSettingsFieldError(document.getElementById('setAlertQuietEnd'));
+  }
+  const message = document.getElementById('settingsMessage');
+  if (message && message.dataset.state === 'error') showSettingsMessage('', '');
+  updateSettingsDirtyState();
+}
+
+function handleSettingsTabKeydown(event) {
+  const current = event.target.closest && event.target.closest('.settings-tab');
+  if (!current) return;
+  const tabs = Array.from(document.querySelectorAll('.settings-tab'));
+  const index = tabs.indexOf(current);
+  if (index < 0) return;
+  let nextIndex = index;
+  if (event.key === 'ArrowDown' || event.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length;
+  else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length;
+  else if (event.key === 'Home') nextIndex = 0;
+  else if (event.key === 'End') nextIndex = tabs.length - 1;
+  else return;
+  event.preventDefault();
+  const next = tabs[nextIndex];
+  switchSettingsTab(next.dataset.settingsTab);
+  next.focus();
+}
+
+function switchSettingsTab(tab) {
+  const nextTab = SETTINGS_TABS.includes(tab) ? tab : 'general';
+  activeSettingsTab = nextTab;
+  SETTINGS_TABS.forEach(name => {
+    const active = nextTab === name;
+    const suffix = name.charAt(0).toUpperCase() + name.slice(1);
+    const tabButton = document.getElementById('settingsTab' + suffix);
+    const panel = document.getElementById('settingsPanel' + suffix);
+    tabButton.classList.toggle('active', active);
+    tabButton.setAttribute('aria-selected', String(active));
+    tabButton.tabIndex = active ? 0 : -1;
+    panel.classList.toggle('active', active);
+    panel.hidden = !active;
+  });
+  storeSettingsTab(nextTab);
+  const activeButton = document.querySelector('[data-settings-tab="' + nextTab + '"]');
+  if (activeButton) {
+    window.requestAnimationFrame(() => activeButton.scrollIntoView({ block: 'nearest', inline: 'nearest' }));
+  }
   const body = document.querySelector('#settingsBackdrop .settings-body');
   if (body) body.scrollTop = 0;
-  if (tab === 'risk') refreshRiskModels();
-  if (tab === 'digest') socket.emit('get_daily_digest_status');
+  if (nextTab === 'risk') refreshRiskModels();
+  if (nextTab === 'digest') socket.emit('get_daily_digest_status');
 }
 
 function openSettings() {
+  settingsLastFocused = document.activeElement;
   applySettings(appSettings);
-  switchSettingsTab('general');
-  document.getElementById('settingsMessage').textContent = '';
+  clearSettingsValidation();
+  showSettingsMessage('', '');
   document.getElementById('settingsBackdrop').classList.add('show');
+  switchSettingsTab(readStoredSettingsTab());
+  resetSettingsDirtySnapshot();
+  window.requestAnimationFrame(() => {
+    const activeTab = document.querySelector('.settings-tab.active');
+    if (activeTab) activeTab.focus();
+  });
 }
 
 function onboardingPriceText() {
@@ -2940,7 +3232,11 @@ function maybeOpenOnboarding() {
 }
 
 function reopenOnboarding() {
-  closeSettings();
+  if (settingsDirty || pendingSettingsSave) {
+    showSettingsMessage('请先保存或放弃当前更改，再重新打开首次使用向导。', 'error');
+    return;
+  }
+  closeSettings(true);
   openOnboarding(true);
 }
 
@@ -2964,15 +3260,91 @@ function skipOnboarding() {
   socket.emit('complete_onboarding', {});
 }
 
-function closeSettings() {
-  document.getElementById('settingsBackdrop').classList.remove('show');
+function hideSettingsDiscardPrompt() {
+  const prompt = document.getElementById('settingsUnsavedConfirm');
+  if (prompt) prompt.hidden = true;
+}
+
+function discardSettingsChanges() {
+  closeSettings(true);
+}
+
+function settingsFocusableElements() {
+  const modal = document.querySelector('.settings-primary-modal');
+  if (!modal) return [];
+  return Array.from(modal.querySelectorAll('button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'))
+    .filter(element => !element.hidden && element.offsetParent !== null);
+}
+
+function handleSettingsDialogKeydown(event) {
+  const backdrop = document.getElementById('settingsBackdrop');
+  if (!backdrop || !backdrop.classList.contains('show')) return;
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closeSettings();
+    return;
+  }
+  if (event.key !== 'Tab') return;
+  const focusable = settingsFocusableElements();
+  if (!focusable.length) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+function closeSettings(force) {
+  const backdrop = document.getElementById('settingsBackdrop');
+  if (!backdrop || !backdrop.classList.contains('show')) return;
+  if (!force && pendingSettingsSave) {
+    showSettingsMessage('设置正在保存，请等待后台确认。', '');
+    return;
+  }
+  if (!force && settingsDirty) {
+    const prompt = document.getElementById('settingsUnsavedConfirm');
+    if (prompt) prompt.hidden = false;
+    const discardButton = document.getElementById('settingsDiscardButton');
+    if (discardButton) discardButton.focus();
+    return;
+  }
+  backdrop.classList.remove('show');
+  hideSettingsDiscardPrompt();
+  clearSettingsValidation();
+  settingsInitialSnapshot = '';
+  settingsDirty = false;
+  if (settingsLastFocused && typeof settingsLastFocused.focus === 'function') settingsLastFocused.focus();
+  settingsLastFocused = null;
 }
 
 function onSettingsBackdrop(event) {
   if (event.target.id === 'settingsBackdrop') closeSettings();
 }
 
+function setupSettingsInteractions() {
+  const backdrop = document.getElementById('settingsBackdrop');
+  const tabs = document.querySelector('.settings-primary-modal .settings-tabs');
+  if (backdrop) {
+    backdrop.addEventListener('input', handleSettingsFieldChange);
+    backdrop.addEventListener('change', handleSettingsFieldChange);
+  }
+  if (tabs) tabs.addEventListener('keydown', handleSettingsTabKeydown);
+  document.addEventListener('keydown', handleSettingsDialogKeydown);
+}
+
+setupSettingsInteractions();
+
 function saveSettings() {
+  if (pendingSettingsSave) return;
+  if (!settingsDirty) {
+    showSettingsMessage('当前没有需要保存的更改。', '');
+    return;
+  }
+  if (!validateSettings()) return;
   const closeBehavior = document.getElementById('setCloseBehavior').value;
   const next = {
     startup_enabled: document.getElementById('setStartup').checked,
@@ -3030,14 +3402,16 @@ function saveSettings() {
   };
   pendingSettingsSave = true;
   settingsSaveFailed = false;
-  document.getElementById('settingsMessage').textContent = '正在保存...';
+  setSettingsSaving(true);
+  showSettingsMessage('正在保存并应用设置...', '');
   socket.emit('update_settings', next);
   if (settingsSaveTimer) clearTimeout(settingsSaveTimer);
   settingsSaveTimer = setTimeout(() => {
     if (!pendingSettingsSave) return;
     pendingSettingsSave = false;
     settingsSaveFailed = true;
-    document.getElementById('settingsMessage').textContent = '保存失败：后台服务未响应，请退出托盘中的旧程序后重新打开最新版。';
+    setSettingsDirty(true);
+    showSettingsMessage('保存失败：后台服务未响应，请退出托盘中的旧程序后重新打开最新版。', 'error');
   }, 5000);
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -247,527 +247,158 @@
 </div>
 
 <div class="settings-backdrop" id="settingsBackdrop" onclick="onSettingsBackdrop(event)">
-  <div class="settings-modal" role="dialog" aria-modal="true" aria-labelledby="settingsTitle">
+  <div class="settings-modal settings-primary-modal" role="dialog" aria-modal="true" aria-labelledby="settingsTitle" aria-describedby="settingsSubtitle">
     <div class="settings-head">
-      <h2 id="settingsTitle">设置</h2>
-      <button class="settings-close" onclick="closeSettings()" aria-label="关闭设置">×</button>
+      <div>
+        <div class="settings-kicker">应用偏好</div>
+        <h2 id="settingsTitle">设置</h2>
+        <p id="settingsSubtitle">管理桌面行为、通知渠道、风险分析和本机数据。</p>
+      </div>
+      <button class="settings-close" type="button" onclick="closeSettings()" aria-label="关闭设置">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18"></path></svg>
+      </button>
     </div>
-    <div class="settings-tabs" role="tablist" aria-label="设置分类">
-      <button class="settings-tab active" id="settingsTabGeneral" type="button" role="tab" aria-selected="true" aria-controls="settingsPanelGeneral" onclick="switchSettingsTab('general')">通用设置</button>
-      <button class="settings-tab" id="settingsTabEmail" type="button" role="tab" aria-selected="false" aria-controls="settingsPanelEmail" onclick="switchSettingsTab('email')">邮件通知</button>
-      <button class="settings-tab" id="settingsTabWebhook" type="button" role="tab" aria-selected="false" aria-controls="settingsPanelWebhook" onclick="switchSettingsTab('webhook')">Webhook</button>
-      <button class="settings-tab" id="settingsTabDigest" type="button" role="tab" aria-selected="false" aria-controls="settingsPanelDigest" onclick="switchSettingsTab('digest')">摘要通知</button>
-      <button class="settings-tab" id="settingsTabRisk" type="button" role="tab" aria-selected="false" aria-controls="settingsPanelRisk" onclick="switchSettingsTab('risk')">风险分析</button>
-      <button class="settings-tab" id="settingsTabOps" type="button" role="tab" aria-selected="false" aria-controls="settingsPanelOps" onclick="switchSettingsTab('ops')">运维</button>
+    <div class="settings-workspace">
+      <aside class="settings-sidebar" aria-label="设置分类导航">
+        <div class="settings-tabs" role="tablist" aria-label="设置分类" aria-orientation="vertical">
+          <button class="settings-tab active" id="settingsTabGeneral" type="button" role="tab" aria-selected="true" aria-controls="settingsPanelGeneral" tabindex="0" data-settings-tab="general" onclick="switchSettingsTab('general')"><span>通用设置</span><small>启动、窗口与提醒</small></button>
+          <button class="settings-tab" id="settingsTabEmail" type="button" role="tab" aria-selected="false" aria-controls="settingsPanelEmail" tabindex="-1" data-settings-tab="email" onclick="switchSettingsTab('email')"><span>邮件通知</span><small>SMTP 与通知模板</small></button>
+          <button class="settings-tab" id="settingsTabWebhook" type="button" role="tab" aria-selected="false" aria-controls="settingsPanelWebhook" tabindex="-1" data-settings-tab="webhook" onclick="switchSettingsTab('webhook')"><span>Webhook</span><small>外部通知连接</small></button>
+          <button class="settings-tab" id="settingsTabDigest" type="button" role="tab" aria-selected="false" aria-controls="settingsPanelDigest" tabindex="-1" data-settings-tab="digest" onclick="switchSettingsTab('digest')"><span>摘要通知</span><small>计划、渠道与预览</small></button>
+          <button class="settings-tab" id="settingsTabRisk" type="button" role="tab" aria-selected="false" aria-controls="settingsPanelRisk" tabindex="-1" data-settings-tab="risk" onclick="switchSettingsTab('risk')"><span>风险分析</span><small>模型连接与成本</small></button>
+          <button class="settings-tab" id="settingsTabOps" type="button" role="tab" aria-selected="false" aria-controls="settingsPanelOps" tabindex="-1" data-settings-tab="ops" onclick="switchSettingsTab('ops')"><span>运维与数据</span><small>备份、诊断与恢复</small></button>
+        </div>
+      </aside>
+      <main class="settings-body">
+        <div class="settings-panel active" id="settingsPanelGeneral" role="tabpanel" aria-labelledby="settingsTabGeneral" data-settings-panel="general">
+          <div class="settings-panel-head"><span>通用设置</span><h3>控制应用在桌面上的运行方式</h3><p>这些设置只影响当前设备，不会修改行情、持仓或预警数据。</p></div>
+          <section class="setting-section">
+            <header class="setting-section-head"><h4>启动与窗口</h4><p>配置开机启动和主窗口关闭行为。</p></header>
+            <div class="setting-row"><div><div class="setting-label">开机自启动</div><div class="setting-desc">开机后自动启动金价监控。</div></div><label class="switch"><input type="checkbox" id="setStartup"><span class="slider"></span></label></div>
+            <div class="setting-row"><div><div class="setting-label" id="startupTrayLabel">自启动时进入托盘</div><div class="setting-desc" id="startupTrayDesc">开机启动后不弹出主窗口，可从右下角托盘打开。</div></div><label class="switch"><input type="checkbox" id="setStartupTray"><span class="slider"></span></label></div>
+            <div class="setting-row"><div><div class="setting-label">关闭窗口时</div><div class="setting-desc">控制点击右上角关闭按钮后的行为。</div></div><select class="settings-select" id="setCloseBehavior"><option value="ask">每次询问</option><option value="minimize_to_tray" id="closeMinimizeOption">最小化到托盘</option><option value="exit">退出程序</option></select></div>
+          </section>
+          <section class="setting-section">
+            <header class="setting-section-head"><h4>桌面悬浮条</h4><p>调整悬浮条内容、尺寸和贴边行为。</p></header>
+            <div class="setting-row"><div><div class="setting-label" id="floatingPriceLabel">桌面金价悬浮条</div><div class="setting-desc" id="floatingPriceDesc">主窗口隐藏时，仍在桌面右下角显示当前金价。</div></div><label class="switch"><input type="checkbox" id="setFloatingPrice"><span class="slider"></span></label></div>
+            <div class="setting-row"><div><div class="setting-label">悬浮条显示内容</div><div class="setting-desc" id="floatingDisplayDesc">控制桌面悬浮条显示人民币、美元或组合内容。</div></div><select class="settings-select" id="setFloatingDisplayMode"><option value="rmb_usd">人民币 + 美元</option><option value="rmb_only">仅人民币</option><option value="usd_only">仅美元</option></select></div>
+            <div class="setting-row" id="floatingPresetRow"><div><div class="setting-label">悬浮条尺寸</div><div class="setting-desc">极简适合长期贴边显示，标准模式保留更多状态信息。</div></div><select class="settings-select" id="setFloatingPreset"><option value="minimal">极简</option><option value="compact">紧凑</option><option value="standard">标准</option></select></div>
+            <div class="setting-row" id="floatingOpacityRow"><div><div class="setting-label">悬浮条透明度</div><div class="setting-desc">范围 50 到 100，数值越高越不透明。</div></div><input class="settings-input smtp-port" id="setFloatingOpacity" type="number" min="50" max="100" step="1" placeholder="94"></div>
+            <div class="setting-row" id="floatingSnapRow"><div><div class="setting-label">悬浮条贴边吸附</div><div class="setting-desc">拖动到屏幕边缘附近时自动贴齐。</div></div><label class="switch"><input type="checkbox" id="setFloatingSnapEdge"><span class="slider"></span></label></div>
+            <div class="setting-row" id="floatingTopmostRow"><div><div class="setting-label">悬浮条始终置顶</div><div class="setting-desc">关闭后，其他应用可以覆盖悬浮条，减少遮挡。</div></div><label class="switch"><input type="checkbox" id="setFloatingAlwaysOnTop"><span class="slider"></span></label></div>
+          </section>
+          <section class="setting-section">
+            <header class="setting-section-head"><h4>提醒行为</h4><p>控制本机提醒方式、冷却时间和静默时段。</p></header>
+            <div class="setting-row"><div><div class="setting-label">告警提示音</div><div class="setting-desc">达到预警条件时播放系统提示音。</div></div><label class="switch"><input type="checkbox" id="setAlertSound"><span class="slider"></span></label></div>
+            <div class="setting-row"><div><div class="setting-label">系统级告警弹窗</div><div class="setting-desc">达到预警条件时弹出置顶提示框。</div></div><label class="switch"><input type="checkbox" id="setAlertDialog"><span class="slider"></span></label></div>
+            <div class="setting-row"><div><div class="setting-label">测试提醒</div><div class="setting-desc">触发一条手动测试提醒，用于检查弹窗、声音和通知链路。</div></div><div class="settings-stack setting-action-status"><button class="settings-cancel btn-form" id="btnTestAlert" type="button" onclick="testAlert()">触发测试</button><span class="test-email-status" id="testAlertStatus"></span></div></div>
+            <div class="setting-row"><div><div class="setting-label">提醒冷却时间</div><div class="setting-desc">同一类型提醒在冷却期内只记录，不重复弹窗或发送通知。</div></div><input class="settings-input smtp-port" id="setAlertCooldownMinutes" type="number" min="0" max="240" step="1" placeholder="30"></div>
+            <div class="setting-row"><div><div class="setting-label">静默时段</div><div class="setting-desc">该时间段内只记录提醒，不弹窗、不响铃、不发送通知。</div></div><div class="settings-stack"><input class="settings-input smtp-port" id="setAlertQuietStart" type="time" aria-label="静默开始时间"><span class="settings-time-separator">至</span><input class="settings-input smtp-port" id="setAlertQuietEnd" type="time" aria-label="静默结束时间"></div></div>
+          </section>
+        </div>
+        <div class="settings-panel" id="settingsPanelEmail" role="tabpanel" aria-labelledby="settingsTabEmail" data-settings-panel="email">
+          <div class="settings-panel-head"><span>邮件通知</span><h3>配置邮件服务与通知内容</h3><p>授权码仅保存在本机凭据存储中，导出普通配置时不会包含原文。</p></div>
+          <section class="setting-section">
+            <header class="setting-section-head"><h4>SMTP 连接</h4><p>填写服务地址、端口和加密方式。</p></header>
+            <div class="setting-row"><div><div class="setting-label">SMTP 服务器</div><div class="setting-desc">邮件服务商 SMTP 地址，例如 smtp.qq.com。</div></div><input class="settings-input" id="setSmtpServer" type="text" placeholder="smtp.qq.com"></div>
+            <div class="setting-row"><div><div class="setting-label">端口</div><div class="setting-desc">SSL 通常为 465，TLS 通常为 587。</div></div><input class="settings-input smtp-port" id="setSmtpPort" type="number" min="1" max="65535" placeholder="465"></div>
+            <div class="setting-row"><div><div class="setting-label">加密方式</div><div class="setting-desc">使用 SSL 或 TLS 建立加密连接。</div></div><select class="settings-select" id="setSmtpEncryption"><option value="ssl">SSL</option><option value="tls">TLS</option></select></div>
+          </section>
+          <section class="setting-section">
+            <header class="setting-section-head"><h4>账户与密钥</h4><p>配置发件账户、授权码和收件地址。</p></header>
+            <div class="setting-row"><div><div class="setting-label">发件邮箱</div><div class="setting-desc">用于发送通知的邮箱地址。</div></div><input class="settings-input" id="setSmtpSender" type="email" placeholder="your@qq.com"></div>
+            <div class="setting-row"><div><div class="setting-label">SMTP 授权码</div><div class="setting-desc setting-status" id="smtpPasswordStatus">未保存授权码。输入授权码后保存即可启用邮件发送。</div></div><div class="settings-stack settings-secret-control"><input class="settings-input" id="setSmtpPassword" type="password" autocomplete="new-password" placeholder="留空表示不修改"><input class="hidden-control" type="checkbox" id="clearSmtpPassword"><button class="settings-cancel btn-form clear-secret-btn" id="clearSmtpPasswordButton" type="button" onclick="toggleSecretClear('clearSmtpPassword', 'smtpPasswordStatus', 'clearSmtpPasswordButton', '保存后将删除已保存的 SMTP 授权码。')">删除已保存授权码</button></div></div>
+            <div class="setting-row"><div><div class="setting-label">收件邮箱</div><div class="setting-desc">接收金价预警通知的邮箱。</div></div><input class="settings-input" id="setSmtpRecipient" type="email" placeholder="receiver@qq.com"></div>
+            <div class="setting-row"><div><div class="setting-label">连接测试</div><div class="setting-desc">发送一封测试邮件验证当前配置。</div></div><div class="settings-stack setting-action-status"><button class="btn-set btn-form" id="btnTestEmail" type="button" onclick="testEmail()">发送测试</button><span class="test-email-status" id="testEmailStatus"></span></div></div>
+          </section>
+          <section class="setting-section">
+            <header class="setting-section-head"><h4>通知模板</h4><p>自定义预警邮件的标题和正文。</p></header>
+            <div class="setting-row"><div><div class="setting-label">邮件标题模板</div><div class="setting-desc">支持 {level}、{title}、{price_rmb}、{price_usd}、{rate}。</div></div><input class="settings-input" id="setEmailSubjectTemplate" type="text" placeholder="[金价预警·{level}] {title}"></div>
+            <div class="setting-row setting-row-top"><div><div class="setting-label">邮件正文模板</div><div class="setting-desc">支持 {message}、{time}、{gold_source}、{rate_source} 等占位符。</div></div><textarea class="settings-textarea" id="setEmailBodyTemplate" placeholder="{message}"></textarea></div>
+          </section>
+        </div>
+        <div class="settings-panel" id="settingsPanelWebhook" role="tabpanel" aria-labelledby="settingsTabWebhook" data-settings-panel="webhook">
+          <div class="settings-panel-head"><span>Webhook</span><h3>将预警发送到外部服务</h3><p>使用 HTTPS 地址接收结构化 JSON，可连接企业协作工具或自建服务。</p></div>
+          <section class="setting-section">
+            <header class="setting-section-head"><h4>连接与投递</h4><p>配置接收地址和需要投递的预警级别。</p></header>
+            <div class="setting-row"><div><div class="setting-label">启用 Webhook</div><div class="setting-desc">达到预警条件时向 Webhook 地址发送 JSON 通知。</div></div><label class="switch"><input type="checkbox" id="setWebhookEnabled"><span class="slider"></span></label></div>
+            <div class="setting-row"><div><div class="setting-label">Webhook 地址</div><div class="setting-desc">支持企业微信、钉钉和自建 HTTPS 接收地址。</div></div><input class="settings-input" id="setWebhookUrl" type="url" placeholder="https://example.com/webhook"></div>
+            <div class="setting-row"><div><div class="setting-label">通知级别</div><div class="setting-desc">分别控制价格、关键和波动预警是否发送。</div></div><div class="settings-stack"><label class="inline-check"><input type="checkbox" id="setWebhookWarning">价格</label><label class="inline-check"><input type="checkbox" id="setWebhookCritical">关键</label><label class="inline-check"><input type="checkbox" id="setWebhookVolatility">波动</label></div></div>
+            <div class="setting-row"><div><div class="setting-label">连接测试</div><div class="setting-desc">发送一条测试请求验证地址是否可用。</div></div><div class="settings-stack setting-action-status"><button class="settings-cancel btn-form" id="btnTestWebhook" type="button" onclick="testWebhook()">发送测试</button><span class="test-email-status" id="testWebhookStatus"></span></div></div>
+          </section>
+        </div>
+        <div class="settings-panel" id="settingsPanelDigest" role="tabpanel" aria-labelledby="settingsTabDigest" data-settings-panel="digest">
+          <div class="settings-panel-head"><span>摘要通知</span><h3>定时汇总最近 24 小时的重要信息</h3><p>摘要包含行情、预警、风险分析、新闻、数据质量和持仓概况。</p></div>
+          <section class="setting-section">
+            <header class="setting-section-head"><h4>发送计划</h4><p>设置每日运行时间和发送渠道。</p></header>
+            <div class="setting-row"><div><div class="setting-label">启用每日摘要</div><div class="setting-desc">按本地时间执行每日摘要任务。</div></div><label class="switch"><input type="checkbox" id="setDailyDigestEnabled" aria-label="启用每日摘要"><span class="slider"></span></label></div>
+            <div class="setting-row"><div><div class="setting-label">发送时间</div><div class="setting-desc">程序在设定时间后启动时，会补发当天尚未完成的摘要。</div></div><input class="settings-input smtp-port" id="setDailyDigestTime" type="time" value="20:00" aria-label="每日摘要发送时间"></div>
+            <div class="setting-row"><div><div class="setting-label">发送渠道</div><div class="setting-desc">邮件与 Webhook 可独立启用，并复用各自连接配置。</div></div><div class="settings-stack"><label class="inline-check"><input type="checkbox" id="setDailyDigestEmail">邮件</label><label class="inline-check"><input type="checkbox" id="setDailyDigestWebhook">Webhook</label></div></div>
+            <div class="setting-row"><div><div class="setting-label">任务状态</div><div class="setting-desc">显示当前计划、渠道和最近一次执行结果。</div></div><span class="setting-status setting-status-wide" id="dailyDigestStatus" aria-live="polite">状态尚未加载。</span></div>
+          </section>
+          <section class="setting-section">
+            <header class="setting-section-head"><h4>预览与测试</h4><p>先检查摘要内容，再决定是否测试发送。</p></header>
+            <div class="setting-row"><div><div class="setting-label">摘要操作</div><div class="setting-desc">预览和测试都不会占用当天计划任务的完成状态。</div></div><div class="settings-stack"><button class="settings-cancel btn-form" id="btnPreviewDailyDigest" type="button" onclick="previewDailyDigest()">生成预览</button><button class="btn-set btn-form" id="btnTestDailyDigest" type="button" onclick="testDailyDigest()">测试发送</button></div></div>
+            <div class="setting-row setting-row-top"><div><div class="setting-label">预览内容</div><div class="setting-desc">测试发送使用相同内容及已保存的渠道配置。</div></div><textarea class="settings-textarea settings-textarea-large" id="dailyDigestPreview" aria-label="每日摘要预览内容" readonly placeholder="点击生成预览后显示摘要内容"></textarea></div>
+          </section>
+        </div>
+        <div class="settings-panel" id="settingsPanelRisk" role="tabpanel" aria-labelledby="settingsTabRisk" data-settings-panel="risk">
+          <div class="settings-panel-head"><span>风险分析</span><h3>配置分析模型和单次调用成本</h3><p>模型只在手动执行风险分析或连接测试时调用，不会后台自动消耗 token。</p></div>
+          <section class="setting-section">
+            <header class="setting-section-head"><h4>分析策略</h4><p>控制功能状态、分析深度和模型提供商。</p></header>
+            <div class="setting-row"><div><div class="setting-label">启用风险分析助手</div><div class="setting-desc">关闭后将隐藏手动风险分析入口。</div></div><label class="switch"><input type="checkbox" id="setRiskAssistantEnabled"><span class="slider"></span></label></div>
+            <div class="setting-row"><div><div class="setting-label">分析深度</div><div class="setting-desc">快速模式消耗更少，深度模式会使用更多历史样本。</div></div><select class="settings-select" id="setRiskAssistantDepth"><option value="quick">快速</option><option value="standard">标准</option><option value="deep">深度</option></select></div>
+            <div class="setting-row"><div><div class="setting-label">模型提供商</div><div class="setting-desc">可使用 DeepSeek 或 OpenAI 兼容服务。</div></div><select class="settings-select" id="setRiskAssistantProvider" onchange="updateRiskProviderFields()"><option value="deepseek">DeepSeek</option><option value="openai_compatible">OpenAI 兼容</option></select></div>
+          </section>
+          <section class="setting-section">
+            <header class="setting-section-head"><h4>模型连接</h4><p>配置当前提供商的接口地址、模型和密钥。</p></header>
+            <div class="setting-row risk-provider-row" data-provider="deepseek"><div><div class="setting-label">DeepSeek API 地址</div><div class="setting-desc">默认使用 DeepSeek 官方 OpenAI 兼容接口。</div></div><input class="settings-input" id="setDeepseekBaseUrl" type="url" placeholder="https://api.deepseek.com"></div>
+            <div class="setting-row risk-provider-row" data-provider="deepseek"><div><div class="setting-label">DeepSeek 模型</div><div class="setting-desc setting-status" id="deepseekModelStatus">默认模型为 deepseek-v4-pro，可从接口自动获取。</div></div><div class="settings-stack"><select class="settings-select" id="setDeepseekModel"></select><button class="settings-cancel btn-form" type="button" onclick="refreshRiskModels()">刷新模型</button></div></div>
+            <div class="setting-row risk-provider-row" data-provider="deepseek"><div><div class="setting-label">DeepSeek API Key</div><div class="setting-desc setting-status" id="deepseekKeyStatus">未保存密钥。输入 API Key 后保存即可启用该模型。</div></div><div class="settings-stack settings-secret-control"><input class="settings-input" id="setDeepseekApiKey" type="password" autocomplete="new-password" placeholder="留空表示不修改"><input class="hidden-control" type="checkbox" id="clearDeepseekApiKey"><button class="settings-cancel btn-form clear-secret-btn" id="clearDeepseekApiKeyButton" type="button" onclick="toggleSecretClear('clearDeepseekApiKey', 'deepseekKeyStatus', 'clearDeepseekApiKeyButton', '保存后将删除已保存的 DeepSeek API Key。')">删除已保存密钥</button></div></div>
+            <div class="setting-row risk-provider-row" data-provider="openai_compatible"><div><div class="setting-label">兼容接口地址</div><div class="setting-desc">填写兼容服务的基础地址，例如 https://example.com/v1。</div></div><input class="settings-input" id="setOpenaiCompatibleBaseUrl" type="url" placeholder="https://example.com/v1"></div>
+            <div class="setting-row risk-provider-row" data-provider="openai_compatible"><div><div class="setting-label">兼容模型</div><div class="setting-desc">填写兼容服务支持的模型名称。</div></div><input class="settings-input" id="setOpenaiCompatibleModel" type="text" placeholder="model-name"></div>
+            <div class="setting-row risk-provider-row" data-provider="openai_compatible"><div><div class="setting-label">兼容 API Key</div><div class="setting-desc setting-status" id="openaiCompatibleKeyStatus">未保存密钥。输入 API Key 后保存即可启用该接口。</div></div><div class="settings-stack settings-secret-control"><input class="settings-input" id="setOpenaiCompatibleApiKey" type="password" autocomplete="new-password" placeholder="留空表示不修改"><input class="hidden-control" type="checkbox" id="clearOpenaiCompatibleApiKey"><button class="settings-cancel btn-form clear-secret-btn" id="clearOpenaiCompatibleApiKeyButton" type="button" onclick="toggleSecretClear('clearOpenaiCompatibleApiKey', 'openaiCompatibleKeyStatus', 'clearOpenaiCompatibleApiKeyButton', '保存后将删除已保存的兼容接口 API Key。')">删除已保存密钥</button></div></div>
+            <div class="setting-row"><div><div class="setting-label">模型连接测试</div><div class="setting-desc">发送一次轻量生成请求，不保存风险分析结果。</div></div><div class="settings-stack setting-action-status"><button class="settings-cancel btn-form" type="button" onclick="testRiskModel()">测试模型</button><span class="model-test-status" id="riskModelTestStatus"></span></div></div>
+          </section>
+          <section class="setting-section">
+            <header class="setting-section-head"><h4>成本控制</h4><p>限制输出规模并避免短时间重复调用。</p></header>
+            <div class="setting-row"><div><div class="setting-label">单次输出上限</div><div class="setting-desc">限制每次分析的最大输出 token。</div></div><input class="settings-input smtp-port" id="setRiskMaxTokens" type="number" min="300" max="4000" step="100" placeholder="1200"></div>
+            <div class="setting-row"><div><div class="setting-label">分析冷却时间</div><div class="setting-desc">两次手动分析之间的最短间隔。</div></div><input class="settings-input smtp-port" id="setRiskCooldownSeconds" type="number" min="0" max="300" step="1" placeholder="15"></div>
+            <div class="setting-row"><div><div class="setting-label">重复分析缓存</div><div class="setting-desc">同一行情快照在此时间内复用最近分析。</div></div><input class="settings-input smtp-port" id="setRiskCacheMinutes" type="number" min="0" max="60" step="1" placeholder="10"></div>
+          </section>
+        </div>
+        <div class="settings-panel" id="settingsPanelOps" role="tabpanel" aria-labelledby="settingsTabOps" data-settings-panel="ops">
+          <div class="settings-panel-head"><span>运维与数据</span><h3>管理本机备份、诊断和应用维护</h3><p>归档和恢复可能包含敏感信息；执行覆盖性操作前请确认文件来源。</p></div>
+          <section class="setting-section">
+            <header class="setting-section-head"><h4>备份与恢复</h4><p>普通配置备份不包含密钥，完整归档包含本机全部数据。</p></header>
+            <div class="setting-row"><div><div class="setting-label">导出配置</div><div class="setting-desc">导出设置、阈值和通知配置，不包含密钥原文。</div></div><button class="btn-set btn-form" type="button" onclick="exportConfig()">导出配置</button></div>
+            <div class="setting-row setting-row-top"><div><div class="setting-label">导入配置</div><div class="setting-desc">粘贴配置备份 JSON 后导入，会覆盖当前相关配置。</div></div><div class="settings-stack settings-stack-column"><textarea class="settings-textarea" id="configImportText" placeholder="粘贴配置备份 JSON"></textarea><button class="settings-cancel btn-form" type="button" onclick="importConfig()">导入配置</button></div></div>
+            <div class="setting-row"><div><div class="setting-label">完整数据归档</div><div class="setting-desc">归档设置、密钥、持仓、预警、复盘和历史数据库。</div></div><button class="btn-set btn-form" type="button" onclick="exportDataArchive()">创建归档</button></div>
+            <div class="setting-row setting-row-top"><div><div class="setting-label">恢复完整数据</div><div class="setting-desc">先校验版本、哈希和数据库完整性，确认后原子恢复。</div></div><div class="settings-stack settings-stack-column"><input id="dataArchiveFile" class="portfolio-import-file" type="file" accept=".zip,application/zip" onchange="previewDataArchive(this)"><div class="settings-stack"><button class="settings-cancel btn-form" type="button" onclick="chooseDataArchive()">选择归档</button><button class="dialog-danger btn-form" id="restoreDataArchiveButton" type="button" onclick="confirmDataArchiveRestore()" hidden>确认恢复</button></div><div class="data-archive-preview" id="dataArchivePreview"></div></div></div>
+          </section>
+          <section class="setting-section">
+            <header class="setting-section-head"><h4>应用维护</h4><p>检查更新、生成诊断并管理导出目录。</p></header>
+            <div class="setting-row"><div><div class="setting-label">首次使用向导</div><div class="setting-desc">重新检查桌面显示、启动行为和本机预警偏好。</div></div><button class="settings-cancel btn-form" type="button" onclick="reopenOnboarding()">重新打开</button></div>
+            <div class="setting-row setting-row-top"><div><div class="setting-label">更新状态</div><div class="setting-desc">查看当前版本、最近检查结果和失败原因。</div></div><div class="settings-stack settings-stack-column ops-update-card"><div class="ops-update-copy"><div class="ops-update-status" id="opsUpdateStatus">尚未检查更新。</div><div class="ops-update-meta" id="opsUpdateMeta">当前版本 {{ app_version }}</div></div><div class="settings-stack"><button class="settings-cancel btn-form" type="button" onclick="checkUpdateFromOps()">检查更新</button><button class="settings-cancel btn-form" type="button" onclick="openUpdateFromOps()">打开更新</button></div></div></div>
+            <div class="setting-row setting-row-top"><div><div class="setting-label">诊断报告</div><div class="setting-desc">导出版本、数据源状态、最近日志和配置摘要。</div></div><div class="settings-stack settings-stack-column"><div class="settings-stack"><button class="btn-set btn-form" type="button" onclick="copyDiagnostics()">复制诊断</button><button class="settings-cancel btn-form" type="button" onclick="exportDiagnostics()">生成诊断</button></div><textarea class="settings-textarea diagnostics-copy-fallback" id="diagnosticsCopyFallback" aria-label="诊断摘要内容" readonly hidden></textarea></div></div>
+            <div class="setting-row setting-row-top"><div><div class="setting-label">导出目录</div><div class="setting-desc setting-status" id="exportDirStatus">留空使用默认导出目录。</div></div><div class="settings-stack settings-stack-column"><input class="settings-input" id="setExportDir" type="text" placeholder="留空使用默认导出目录"><div class="settings-stack"><button class="settings-cancel btn-form" id="chooseExportDirButton" type="button" onclick="chooseExportDir()">选择目录</button><button class="settings-cancel btn-form" type="button" onclick="resetExportDirField()">使用默认</button><button class="settings-cancel btn-form" type="button" onclick="openExportsFolder()">打开目录</button></div></div></div>
+            <div class="setting-row setting-row-top"><div><div class="setting-label">最近操作记录</div><div class="setting-desc">显示本次会话内的导出配置、生成诊断和打开目录结果。</div></div><div class="settings-stack ops-recent-card"><div class="ops-recent-list" id="recentOpsList"><div class="ops-recent-empty">暂无操作记录</div></div></div></div>
+          </section>
+          <section class="setting-section setting-section-danger">
+            <header class="setting-section-head"><h4>危险操作</h4><p>以下操作会覆盖当前设置或数据，执行前请确认已完成备份。</p></header>
+            <div class="setting-row setting-row-danger"><div><div class="setting-label">恢复默认设置</div><div class="setting-desc">重置通用、邮件、风险分析和提醒设置，并清空阈值。</div></div><button class="dialog-danger btn-form" type="button" onclick="resetSettings()">恢复默认</button></div>
+          </section>
+          <div class="ops-status" id="opsStatus"></div>
+        </div>
+      </main>
     </div>
-    <div class="settings-body">
-      <div class="settings-panel active" id="settingsPanelGeneral" role="tabpanel" aria-labelledby="settingsTabGeneral">
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">开机自启动</div>
-            <div class="setting-desc">开机后自动启动金价监控。</div>
-          </div>
-          <label class="switch"><input type="checkbox" id="setStartup"><span class="slider"></span></label>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label" id="startupTrayLabel">自启动时进入托盘</div>
-            <div class="setting-desc" id="startupTrayDesc">开机启动后不弹出主窗口，可从右下角托盘打开。</div>
-          </div>
-          <label class="switch"><input type="checkbox" id="setStartupTray"><span class="slider"></span></label>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label" id="floatingPriceLabel">桌面金价悬浮条</div>
-            <div class="setting-desc" id="floatingPriceDesc">主窗口隐藏时，仍在桌面右下角显示当前金价。</div>
-          </div>
-          <label class="switch"><input type="checkbox" id="setFloatingPrice"><span class="slider"></span></label>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">悬浮条显示内容</div>
-            <div class="setting-desc" id="floatingDisplayDesc">控制桌面悬浮条显示人民币、美元或组合内容。</div>
-          </div>
-          <select class="settings-select" id="setFloatingDisplayMode">
-            <option value="rmb_usd">人民币 + 美元</option>
-            <option value="rmb_only">仅人民币</option>
-            <option value="usd_only">仅美元</option>
-          </select>
-        </div>
-        <div class="setting-row" id="floatingPresetRow">
-          <div>
-            <div class="setting-label">悬浮条尺寸</div>
-            <div class="setting-desc">极简适合长期贴边显示，标准模式保留更多状态信息。</div>
-          </div>
-          <select class="settings-select" id="setFloatingPreset">
-            <option value="minimal">极简</option>
-            <option value="compact">紧凑</option>
-            <option value="standard">标准</option>
-          </select>
-        </div>
-        <div class="setting-row" id="floatingOpacityRow">
-          <div>
-            <div class="setting-label">悬浮条透明度</div>
-            <div class="setting-desc">范围 50 到 100，数值越高越不透明。</div>
-          </div>
-          <input class="settings-input smtp-port" id="setFloatingOpacity" type="number" min="50" max="100" step="1" placeholder="94">
-        </div>
-        <div class="setting-row" id="floatingSnapRow">
-          <div>
-            <div class="setting-label">悬浮条贴边吸附</div>
-            <div class="setting-desc">拖动到屏幕边缘附近时自动贴齐。</div>
-          </div>
-          <label class="switch"><input type="checkbox" id="setFloatingSnapEdge"><span class="slider"></span></label>
-        </div>
-        <div class="setting-row" id="floatingTopmostRow">
-          <div>
-            <div class="setting-label">悬浮条始终置顶</div>
-            <div class="setting-desc">关闭后，其他应用可以覆盖悬浮条，减少遮挡。</div>
-          </div>
-          <label class="switch"><input type="checkbox" id="setFloatingAlwaysOnTop"><span class="slider"></span></label>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">关闭窗口时</div>
-            <div class="setting-desc">控制点击右上角关闭按钮后的行为。</div>
-          </div>
-          <select class="settings-select" id="setCloseBehavior">
-            <option value="ask">每次询问</option>
-            <option value="minimize_to_tray" id="closeMinimizeOption">最小化到托盘</option>
-            <option value="exit">退出程序</option>
-          </select>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">告警提示音</div>
-            <div class="setting-desc">达到预警条件时播放系统提示音。</div>
-          </div>
-          <label class="switch"><input type="checkbox" id="setAlertSound"><span class="slider"></span></label>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">系统级告警弹窗</div>
-            <div class="setting-desc">达到预警条件时弹出置顶提示框。</div>
-          </div>
-          <label class="switch"><input type="checkbox" id="setAlertDialog"><span class="slider"></span></label>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">测试提醒</div>
-            <div class="setting-desc">触发一条手动测试提醒，用于检查弹窗、声音和通知链路。</div>
-          </div>
-          <button class="settings-cancel btn-form" id="btnTestAlert" onclick="testAlert()">触发测试</button>
-          <span class="test-email-status" id="testAlertStatus"></span>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">提醒冷却时间</div>
-            <div class="setting-desc">同一类型提醒在冷却期内只记录，不重复弹窗或发送通知。</div>
-          </div>
-          <input class="settings-input smtp-port" id="setAlertCooldownMinutes" type="number" min="0" max="240" step="1" placeholder="30">
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">静默时段</div>
-            <div class="setting-desc">该时间段内只记录提醒，不弹窗、不响铃、不发送通知。</div>
-          </div>
-          <div class="settings-stack">
-            <input class="settings-input smtp-port" id="setAlertQuietStart" type="time">
-            <input class="settings-input smtp-port" id="setAlertQuietEnd" type="time">
-          </div>
-        </div>
-      </div>
-      <div class="settings-panel" id="settingsPanelEmail" role="tabpanel" aria-labelledby="settingsTabEmail">
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">SMTP 服务器</div>
-            <div class="setting-desc">邮件服务商 SMTP 地址 (如 smtp.qq.com)。</div>
-          </div>
-          <input class="settings-input" id="setSmtpServer" type="text" placeholder="smtp.qq.com">
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">端口</div>
-            <div class="setting-desc">SSL 通常为 465，TLS 通常为 587。</div>
-          </div>
-          <input class="settings-input smtp-port" id="setSmtpPort" type="number" placeholder="465">
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">加密方式</div>
-            <div class="setting-desc">SSL 或 TLS 加密连接。</div>
-          </div>
-          <select class="settings-select" id="setSmtpEncryption">
-            <option value="ssl">SSL</option>
-            <option value="tls">TLS</option>
-          </select>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">发件邮箱</div>
-            <div class="setting-desc">用于发送通知的邮箱地址。</div>
-          </div>
-          <input class="settings-input" id="setSmtpSender" type="email" placeholder="your@qq.com">
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">SMTP 授权码</div>
-            <div class="setting-desc" id="smtpPasswordStatus">未保存授权码。输入授权码后保存即可启用邮件发送。</div>
-          </div>
-          <input class="settings-input" id="setSmtpPassword" type="password" placeholder="留空表示不修改">
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">已保存授权码</div>
-            <div class="setting-desc">不再使用当前授权码时，可删除本机保存的授权码。</div>
-          </div>
-          <input class="hidden-control" type="checkbox" id="clearSmtpPassword">
-          <button class="settings-cancel btn-form clear-secret-btn" id="clearSmtpPasswordButton" type="button" onclick="toggleSecretClear('clearSmtpPassword', 'smtpPasswordStatus', 'clearSmtpPasswordButton', '保存后将删除已保存的 SMTP 授权码。')">删除已保存授权码</button>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">收件邮箱</div>
-            <div class="setting-desc">接收金价预警通知的邮箱。</div>
-          </div>
-          <input class="settings-input" id="setSmtpRecipient" type="email" placeholder="receiver@qq.com">
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">测试邮件</div>
-            <div class="setting-desc">发送一封测试邮件验证配置是否正确。</div>
-          </div>
-          <button class="btn-set btn-form" id="btnTestEmail" onclick="testEmail()">发送测试</button>
-          <span class="test-email-status" id="testEmailStatus"></span>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">邮件标题模板</div>
-            <div class="setting-desc">支持 {level}、{title}、{price_rmb}、{price_usd}、{rate}。</div>
-          </div>
-          <input class="settings-input" id="setEmailSubjectTemplate" type="text" placeholder="[金价预警·{level}] {title}">
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">邮件正文模板</div>
-            <div class="setting-desc">支持 {message}、{time}、{gold_source}、{rate_source} 等占位符。</div>
-          </div>
-          <textarea class="settings-textarea" id="setEmailBodyTemplate" placeholder="{message}"></textarea>
-        </div>
-      </div>
-      <div class="settings-panel" id="settingsPanelWebhook" role="tabpanel" aria-labelledby="settingsTabWebhook">
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">启用 Webhook</div>
-            <div class="setting-desc">达到预警条件时向 HTTPS Webhook 地址发送 JSON 通知。</div>
-          </div>
-          <label class="switch"><input type="checkbox" id="setWebhookEnabled"><span class="slider"></span></label>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">Webhook 地址</div>
-            <div class="setting-desc">支持企业微信、钉钉、自建服务等 HTTPS 接收地址。</div>
-          </div>
-          <input class="settings-input" id="setWebhookUrl" type="url" placeholder="https://example.com/webhook">
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">Webhook 分级</div>
-            <div class="setting-desc">分别控制价格预警、关键预警和波动预警是否发送 Webhook。</div>
-          </div>
-          <div class="settings-stack">
-            <label class="inline-check"><input type="checkbox" id="setWebhookWarning"> 价格</label>
-            <label class="inline-check"><input type="checkbox" id="setWebhookCritical"> 关键</label>
-            <label class="inline-check"><input type="checkbox" id="setWebhookVolatility"> 波动</label>
-          </div>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">测试 Webhook</div>
-            <div class="setting-desc">发送一条测试 JSON 请求验证地址是否可用。</div>
-          </div>
-          <button class="settings-cancel btn-form" id="btnTestWebhook" onclick="testWebhook()">发送测试</button>
-          <span class="test-email-status" id="testWebhookStatus"></span>
-        </div>
-      </div>
-      <div class="settings-panel" id="settingsPanelDigest" role="tabpanel" aria-labelledby="settingsTabDigest">
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">启用每日摘要</div>
-            <div class="setting-desc">每天按本地时间汇总最近 24 小时的行情、预警、风险分析、新闻、数据质量和持仓。</div>
-          </div>
-          <label class="switch"><input type="checkbox" id="setDailyDigestEnabled" aria-label="启用每日摘要"><span class="slider"></span></label>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">发送时间</div>
-            <div class="setting-desc">程序在设定时间后启动时，会补发当天尚未完成的摘要。</div>
-          </div>
-          <input class="settings-input smtp-port" id="setDailyDigestTime" type="time" value="20:00" aria-label="每日摘要发送时间">
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">发送渠道</div>
-            <div class="setting-desc">邮件与 Webhook 可独立启用，并复用各自通知页中的连接配置。</div>
-          </div>
-          <div class="settings-stack">
-            <label class="inline-check"><input type="checkbox" id="setDailyDigestEmail"> 邮件</label>
-            <label class="inline-check"><input type="checkbox" id="setDailyDigestWebhook"> Webhook</label>
-          </div>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">任务状态</div>
-            <div class="setting-desc">显示当前计划、通知渠道和最近一次执行结果。</div>
-          </div>
-          <span class="test-email-status" id="dailyDigestStatus" aria-live="polite">状态尚未加载。</span>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">摘要预览</div>
-            <div class="setting-desc">预览不会发送通知，也不会占用当天的计划发送资格。</div>
-          </div>
-          <div class="settings-stack">
-            <button class="settings-cancel btn-form" id="btnPreviewDailyDigest" type="button" onclick="previewDailyDigest()">生成预览</button>
-            <button class="btn-set btn-form" id="btnTestDailyDigest" type="button" onclick="testDailyDigest()">测试发送</button>
-          </div>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">预览内容</div>
-            <div class="setting-desc">测试发送使用相同内容及已保存的渠道配置，但不会改变当天计划任务的完成状态。</div>
-          </div>
-          <textarea class="settings-textarea" id="dailyDigestPreview" aria-label="每日摘要预览内容" readonly placeholder="点击生成预览后显示摘要内容"></textarea>
-        </div>
-      </div>
-      <div class="settings-panel" id="settingsPanelRisk" role="tabpanel" aria-labelledby="settingsTabRisk">
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">启用风险分析助手</div>
-            <div class="setting-desc">仅在手动点击风险分析时调用模型，不会自动消耗 token。</div>
-          </div>
-          <label class="switch"><input type="checkbox" id="setRiskAssistantEnabled"><span class="slider"></span></label>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">分析深度</div>
-            <div class="setting-desc">快速模式消耗更少，深度模式会使用更多历史样本。</div>
-          </div>
-          <select class="settings-select" id="setRiskAssistantDepth">
-            <option value="quick">快速</option>
-            <option value="standard">标准</option>
-            <option value="deep">深度</option>
-          </select>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">模型提供商</div>
-            <div class="setting-desc">当前版本优先支持 DeepSeek。</div>
-          </div>
-          <select class="settings-select" id="setRiskAssistantProvider" onchange="updateRiskProviderFields()">
-            <option value="deepseek">DeepSeek</option>
-            <option value="openai_compatible">OpenAI 兼容</option>
-          </select>
-        </div>
-        <div class="setting-row risk-provider-row" data-provider="deepseek">
-          <div>
-            <div class="setting-label">DeepSeek API 地址</div>
-            <div class="setting-desc">默认使用 DeepSeek 官方 OpenAI 兼容接口。</div>
-          </div>
-          <input class="settings-input" id="setDeepseekBaseUrl" type="url" placeholder="https://api.deepseek.com">
-        </div>
-        <div class="setting-row risk-provider-row" data-provider="deepseek">
-          <div>
-            <div class="setting-label">DeepSeek 模型</div>
-            <div class="setting-desc" id="deepseekModelStatus">默认模型为 deepseek-v4-pro，可从接口自动获取。</div>
-          </div>
-          <div class="settings-stack">
-            <select class="settings-select" id="setDeepseekModel"></select>
-            <button class="settings-cancel risk-history-clear" type="button" onclick="refreshRiskModels()">刷新模型</button>
-          </div>
-        </div>
-        <div class="setting-row risk-provider-row" data-provider="deepseek">
-          <div>
-            <div class="setting-label">DeepSeek API Key</div>
-            <div class="setting-desc" id="deepseekKeyStatus">未保存密钥。输入 API Key 后保存即可启用该模型。</div>
-          </div>
-          <input class="settings-input" id="setDeepseekApiKey" type="password" placeholder="留空表示不修改">
-        </div>
-        <div class="setting-row risk-provider-row" data-provider="deepseek">
-          <div>
-            <div class="setting-label">已保存 DeepSeek Key</div>
-            <div class="setting-desc">不再使用当前密钥时，可删除本机保存的 DeepSeek API Key。</div>
-          </div>
-          <input class="hidden-control" type="checkbox" id="clearDeepseekApiKey">
-          <button class="settings-cancel btn-form clear-secret-btn" id="clearDeepseekApiKeyButton" type="button" onclick="toggleSecretClear('clearDeepseekApiKey', 'deepseekKeyStatus', 'clearDeepseekApiKeyButton', '保存后将删除已保存的 DeepSeek API Key。')">删除已保存密钥</button>
-        </div>
-        <div class="setting-row risk-provider-row" data-provider="openai_compatible">
-          <div>
-            <div class="setting-label">兼容接口地址</div>
-            <div class="setting-desc">填写 OpenAI 兼容服务的基础地址，例如 https://example.com/v1。</div>
-          </div>
-          <input class="settings-input" id="setOpenaiCompatibleBaseUrl" type="url" placeholder="https://example.com/v1">
-        </div>
-        <div class="setting-row risk-provider-row" data-provider="openai_compatible">
-          <div>
-            <div class="setting-label">兼容模型</div>
-            <div class="setting-desc">填写兼容服务支持的模型名称。</div>
-          </div>
-          <input class="settings-input" id="setOpenaiCompatibleModel" type="text" placeholder="model-name">
-        </div>
-        <div class="setting-row risk-provider-row" data-provider="openai_compatible">
-          <div>
-            <div class="setting-label">兼容 API Key</div>
-            <div class="setting-desc" id="openaiCompatibleKeyStatus">未保存密钥。输入 API Key 后保存即可启用该接口。</div>
-          </div>
-          <input class="settings-input" id="setOpenaiCompatibleApiKey" type="password" placeholder="留空表示不修改">
-        </div>
-        <div class="setting-row risk-provider-row" data-provider="openai_compatible">
-          <div>
-            <div class="setting-label">已保存兼容 Key</div>
-            <div class="setting-desc">不再使用当前密钥时，可删除本机保存的兼容 API Key。</div>
-          </div>
-          <input class="hidden-control" type="checkbox" id="clearOpenaiCompatibleApiKey">
-          <button class="settings-cancel btn-form clear-secret-btn" id="clearOpenaiCompatibleApiKeyButton" type="button" onclick="toggleSecretClear('clearOpenaiCompatibleApiKey', 'openaiCompatibleKeyStatus', 'clearOpenaiCompatibleApiKeyButton', '保存后将删除已保存的兼容接口 API Key。')">删除已保存密钥</button>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">模型连接测试</div>
-            <div class="setting-desc">发送一次轻量生成请求验证当前模型，不保存风险分析结果。</div>
-          </div>
-          <div class="settings-stack">
-            <button class="settings-cancel risk-history-clear" type="button" onclick="testRiskModel()">测试模型</button>
-            <span class="model-test-status" id="riskModelTestStatus"></span>
-          </div>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">单次输出上限</div>
-            <div class="setting-desc">限制每次分析的最大输出 token，控制成本。</div>
-          </div>
-          <input class="settings-input smtp-port" id="setRiskMaxTokens" type="number" min="300" max="4000" step="100" placeholder="1200">
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">分析冷却时间</div>
-            <div class="setting-desc">两次手动分析之间的最短间隔，避免误点重复消耗。</div>
-          </div>
-          <input class="settings-input smtp-port" id="setRiskCooldownSeconds" type="number" min="0" max="300" step="1" placeholder="15">
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">重复分析缓存</div>
-            <div class="setting-desc">同一行情快照在此时间内复用最近分析，避免重复消耗 token。</div>
-          </div>
-          <input class="settings-input smtp-port" id="setRiskCacheMinutes" type="number" min="0" max="60" step="1" placeholder="10">
-        </div>
-      </div>
-      <div class="settings-panel" id="settingsPanelOps" role="tabpanel" aria-labelledby="settingsTabOps">
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">导出配置</div>
-            <div class="setting-desc">导出本机设置、阈值和通知配置，备份文件不包含密钥原文。</div>
-          </div>
-          <button class="btn-set btn-form" type="button" onclick="exportConfig()">导出配置</button>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">导入配置</div>
-            <div class="setting-desc">粘贴配置备份 JSON 后导入，会覆盖当前相关配置。</div>
-          </div>
-          <div class="settings-stack">
-            <textarea class="settings-textarea" id="configImportText" placeholder="粘贴配置备份 JSON"></textarea>
-            <button class="settings-cancel btn-form" type="button" onclick="importConfig()">导入</button>
-          </div>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">完整数据归档</div>
-            <div class="setting-desc">归档设置、密钥、持仓、预警、复盘和历史数据库。归档含敏感信息，请妥善保管。</div>
-          </div>
-          <button class="btn-set btn-form" type="button" onclick="exportDataArchive()">创建归档</button>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">恢复完整数据</div>
-            <div class="setting-desc">先校验归档版本、哈希和数据库完整性，确认后原子恢复；失败时自动回滚。</div>
-          </div>
-          <div class="settings-stack">
-            <input id="dataArchiveFile" class="portfolio-import-file" type="file" accept=".zip,application/zip" onchange="previewDataArchive(this)">
-            <button class="settings-cancel btn-form" type="button" onclick="chooseDataArchive()">选择归档</button>
-            <button class="dialog-danger btn-form" id="restoreDataArchiveButton" type="button" onclick="confirmDataArchiveRestore()" hidden>确认恢复</button>
-            <div class="data-archive-preview" id="dataArchivePreview"></div>
-          </div>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">首次使用向导</div>
-            <div class="setting-desc">重新检查桌面显示、启动行为和本机预警偏好，不修改持仓或预警规则。</div>
-          </div>
-          <button class="settings-cancel btn-form" type="button" onclick="reopenOnboarding()">重新打开</button>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">更新状态</div>
-            <div class="setting-desc">查看当前版本、最近检查结果和失败原因，必要时复制诊断摘要。</div>
-          </div>
-          <div class="settings-stack ops-update-card">
-            <div class="ops-update-copy">
-              <div class="ops-update-status" id="opsUpdateStatus">尚未检查更新。</div>
-              <div class="ops-update-meta" id="opsUpdateMeta">当前版本 {{ app_version }}</div>
-            </div>
-            <button class="settings-cancel btn-form" type="button" onclick="checkUpdateFromOps()">检查更新</button>
-            <button class="settings-cancel btn-form" type="button" onclick="openUpdateFromOps()">打开更新</button>
-            <button class="btn-set btn-form" type="button" onclick="copyDiagnostics()">复制诊断</button>
-          </div>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">诊断报告</div>
-            <div class="setting-desc">导出版本、数据源状态、最近日志和配置摘要，便于排查问题。</div>
-          </div>
-          <div class="settings-stack">
-            <button class="btn-set btn-form" type="button" onclick="copyDiagnostics()">复制诊断</button>
-            <button class="settings-cancel btn-form" type="button" onclick="exportDiagnostics()">生成诊断</button>
-            <textarea class="settings-textarea diagnostics-copy-fallback" id="diagnosticsCopyFallback" aria-label="诊断摘要内容" readonly hidden></textarea>
-          </div>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">导出目录</div>
-            <div class="setting-desc" id="exportDirStatus">留空使用默认导出目录。</div>
-          </div>
-          <div class="settings-stack">
-            <input class="settings-input" id="setExportDir" type="text" placeholder="留空使用默认导出目录">
-            <button class="settings-cancel btn-form" id="chooseExportDirButton" type="button" onclick="chooseExportDir()">选择目录</button>
-            <button class="settings-cancel btn-form" type="button" onclick="resetExportDirField()">使用默认</button>
-            <button class="settings-cancel btn-form" type="button" onclick="openExportsFolder()">打开目录</button>
-          </div>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">最近操作记录</div>
-            <div class="setting-desc">显示本次会话内的导出配置、生成诊断和打开目录结果。</div>
-          </div>
-          <div class="settings-stack ops-recent-card">
-            <div class="ops-recent-list" id="recentOpsList">
-              <div class="ops-recent-empty">暂无操作记录</div>
-            </div>
-          </div>
-        </div>
-        <div class="setting-row">
-          <div>
-            <div class="setting-label">恢复默认设置</div>
-            <div class="setting-desc">重置通用、邮件、风险分析和提醒设置，并清空阈值。</div>
-          </div>
-          <button class="dialog-danger btn-form" type="button" onclick="resetSettings()">恢复默认</button>
-        </div>
-        <div class="ops-status" id="opsStatus"></div>
-      </div>
+    <div class="settings-unsaved" id="settingsUnsavedConfirm" hidden role="alert">
+      <div><strong>有未保存的更改</strong><span>关闭设置将放弃本次修改。</span></div>
+      <div class="settings-unsaved-actions"><button class="settings-cancel" type="button" onclick="hideSettingsDiscardPrompt()">继续编辑</button><button class="dialog-danger" id="settingsDiscardButton" type="button" onclick="discardSettingsChanges()">放弃更改</button></div>
     </div>
-    <div class="settings-message" id="settingsMessage"></div>
     <div class="settings-foot">
-      <button class="settings-cancel" onclick="closeSettings()">取消</button>
-      <button class="settings-save" onclick="saveSettings()">保存</button>
+      <div class="settings-foot-copy"><span class="settings-dirty-state" id="settingsDirtyState">尚未修改</span><div class="settings-message" id="settingsMessage" role="status" aria-live="polite"></div></div>
+      <div class="settings-foot-actions"><button class="settings-cancel" id="settingsCancelButton" type="button" onclick="closeSettings()">取消</button><button class="settings-save" id="settingsSaveButton" type="button" onclick="saveSettings()" disabled>保存更改</button></div>
     </div>
   </div>
 </div>

--- a/tests/frontend_asset_check.py
+++ b/tests/frontend_asset_check.py
@@ -218,6 +218,40 @@ apply_settings_pos = js.find("applySettings(data || {})", settings_updated_pos)
 if not (settings_updated_pos >= 0 and settings_failed_pos >= 0 and apply_settings_pos >= 0 and settings_failed_pos < apply_settings_pos):
     raise SystemExit("settings_updated must preserve visible settings_error state before repainting the form")
 
+for required in (
+    'class="settings-modal settings-primary-modal"',
+    'class="settings-workspace"',
+    'aria-orientation="vertical"',
+    'class="setting-section setting-section-danger"',
+    'id="settingsUnsavedConfirm"',
+    'id="settingsDirtyState"',
+    'id="settingsSaveButton"',
+    'function captureSettingsSnapshot',
+    'function validateSettings',
+    'function handleSettingsTabKeydown',
+    'function handleSettingsDialogKeydown',
+    'SETTINGS_TAB_STORAGE_KEY',
+):
+    if required not in template + js:
+        raise SystemExit(f"frontend missing settings workspace contract: {required}")
+
+for required in (
+    '.settings-primary-modal',
+    '.settings-workspace',
+    '.settings-sidebar',
+    '.setting-section',
+    '.settings-unsaved',
+    '.setting-field-error',
+    'grid-template-columns:132px minmax(0, 1fr)',
+    'grid-template-columns:106px minmax(0, 1fr)',
+    '.settings-tab small { display:none; }',
+):
+    if required not in css:
+        raise SystemExit(f"static/app.css missing settings workspace selector: {required}")
+
+if '.settings-workspace { display:flex; flex-direction:column; }' in css:
+    raise SystemExit("settings navigation must remain on the left at narrow widths")
+
 reset_export_dir_pos = js.find("function resetExportDirField()")
 reset_export_dir_clear_pos = js.find("clearSettingsMessage();", reset_export_dir_pos)
 reset_export_dir_status_pos = js.find("renderExportDirStatus(null", reset_export_dir_pos)
@@ -865,7 +899,7 @@ for required in (
     "socket.on('daily_digest_previewed'",
     "socket.on('daily_digest_test_result'",
     "if (data.daily_digest_status) applyDailyDigestStatus(data.daily_digest_status)",
-    "if (tab === 'digest') socket.emit('get_daily_digest_status')",
+    "if (nextTab === 'digest') socket.emit('get_daily_digest_status')",
     "daily_digest_enabled: document.getElementById('setDailyDigestEnabled').checked",
     "daily_digest_time: document.getElementById('setDailyDigestTime').value",
     "daily_digest_email_enabled: document.getElementById('setDailyDigestEmail').checked",


### PR DESCRIPTION
## 变更目标

重新设计设置页面的信息架构与交互，解决顶部横向 Tab 视觉拥挤、设置项层级不清以及窄窗口可用性不足的问题。

## 变更范围

- 将设置分类改为左侧纵向导航，并在窄窗口下保持左侧布局。
- 调整设置弹窗尺寸、内容分组、表单布局和危险操作区域。
- 增加未保存状态、关闭确认、分类记忆和保存结果反馈。
- 增加跨分类校验、键盘导航、焦点管理和无障碍属性。
- 保留原有字段 ID、数据结构及后端配置契约。
- 补充前端资源契约检查，覆盖设置页关键结构和响应式规则。

## 验证结果

- [x] `node --check static/app.js`
- [x] `.venv/bin/python tests/frontend_asset_check.py`
- [x] `git diff --check`
- [x] 改造阶段完整项目检查：269 项测试通过。
- [x] 600 × 900 窄窗口浏览器验证通过。

## 影响检查

- [x] 已补充或更新相关前端检查。
- [x] 已检查文档影响，本次无需调整用户文档。
- [x] 已检查配置、持久化和 Socket.IO 契约，原有契约保持不变。
- [x] 未提交 API Key、SMTP 授权码、Webhook URL、用户数据或本机敏感信息。
- [x] 前端文本未使用 Emoji。

## 关联 Issue

暂无关联 Issue，本次变更来自已确认的设置页视觉与交互完善需求。
