### PR TITLE
[codex] 修复应用重启后预警状态未刷新

### DIFF
--- a/goldmonitor/alert_runtime.py
+++ b/goldmonitor/alert_runtime.py
@@ -740,7 +740,7 @@ class AlertRuntime:
             **simulation,
         }
 
-    def check_rules(self, now_str=None, now=None):
+    def check_rules(self, now_str=None, now=None, force_emit=False):
         now = now or self.now_factory()
         with self.state.lock:
             portfolio_state = self.build_portfolio_state()
@@ -767,8 +767,9 @@ class AlertRuntime:
             watch_state = self.watch_targets_state()
             portfolio_state = self.build_portfolio_state()
 
-        if changed:
+        if changed or force_emit:
             self.emit_event("alert_rules_updated", rules_state)
+        if changed:
             self.emit_event("watch_targets_updated", watch_state)
             self.emit_event("portfolio_updated", portfolio_state)
         for trigger in triggers:

--- a/goldmonitor/application.py
+++ b/goldmonitor/application.py
@@ -1190,9 +1190,13 @@ def check_portfolio_alerts(now_str):
         return _get_portfolio_runtime().check_alerts(now_str)
 
 
-def check_alert_rules(now_str=None, now=None):
+def check_alert_rules(now_str=None, now=None, force_emit=False):
 
-        return _get_alert_runtime().check_rules(now_str=now_str, now=now)
+        return _get_alert_runtime().check_rules(
+            now_str=now_str,
+            now=now,
+            force_emit=force_emit,
+        )
 
 
 def upsert_portfolio_position(data):

--- a/goldmonitor/market_runtime.py
+++ b/goldmonitor/market_runtime.py
@@ -597,6 +597,8 @@ class MarketRuntime:
                     state["usdcny_rate_time"] = rate_time
                     state["usdcny_rate_cached"] = rate_cached
                     state["usdcny_rate_error"] = forex_error or ""
+                had_price_usd = state["price_usd"] is not None
+                had_price_rmb = state["price_rmb"] is not None
                 state["previous_usd"] = state["price_usd"]
                 state["previous_rmb"] = state["price_rmb"]
                 state["price_usd"] = data["close"]
@@ -737,7 +739,15 @@ class MarketRuntime:
                 desktop_title = self.format_price_title(state["price_rmb"], state["price_usd"])
                 self.update_desktop_price_title(desktop_title)
                 self.update_floating_price(state["price_rmb"], state["price_usd"], pct_rmb)
-                self.check_alert_rules(now_str, now=now)
+                first_price_ready = (
+                    (not had_price_usd and state["price_usd"] is not None)
+                    or (not had_price_rmb and state["price_rmb"] is not None)
+                )
+                self.check_alert_rules(
+                    now_str,
+                    now=now,
+                    force_emit=first_price_ready,
+                )
 
                 if cny_rate:
                     rate_message = (

--- a/tests/test_domain_runtime_modules.py
+++ b/tests/test_domain_runtime_modules.py
@@ -72,6 +72,71 @@ def test_alert_runtime_syncs_unified_rules_into_legacy_views():
     assert state.portfolio_alerts == []
 
 
+def test_alert_runtime_force_emits_view_when_first_market_data_becomes_available():
+    from goldmonitor import alert_rules as alert_rules_core
+    from goldmonitor.alert_runtime import AlertRuntime
+
+    state = _state()
+    rules, _rule = alert_rules_core.upsert_alert_rule(
+        [],
+        {
+            "kind": "price_threshold",
+            "name": "人民币下跌关注",
+            "scope": {"mode": "rmb"},
+            "condition": {"operator": "lte", "value": 680},
+            "alert_level": "warning",
+        },
+        now_factory=lambda: datetime(2026, 7, 30, 12, 0),
+        id_factory=lambda: "rule-startup",
+    )
+    state.alert_rules = rules
+    emitted = []
+    runtime = AlertRuntime(
+        state,
+        rule_store_factory=lambda: None,
+        load_thresholds=dict,
+        load_watch_targets=list,
+        load_portfolio_alerts=list,
+        build_portfolio_state=lambda: {"items": []},
+        normalize_volatility=lambda value: value,
+        save_watch_targets=lambda items: items,
+        emit_event=lambda event, payload: emitted.append((event, payload)),
+        emit_alert=lambda *args: None,
+        get_settings=dict,
+        alert_log_reader=lambda **kwargs: [],
+        history_reader=lambda *args, **kwargs: [],
+        history_timestamp=lambda value: None,
+        alert_log_export_limit=1000,
+        simulation_point_limit=30000,
+        threshold_modes=("usd", "rmb"),
+        threshold_types=(
+            "upper_warning",
+            "upper_critical",
+            "lower_warning",
+            "lower_critical",
+        ),
+        watch_target_note_limit=200,
+        now_factory=lambda: datetime(2026, 7, 30, 12, 0),
+    )
+
+    initial_state = runtime.get_state()
+    assert initial_state["items"][0]["state"]["status"] == "waiting_data"
+
+    state.price_rmb = 700.0
+    assert runtime.check_rules(
+        "12:00:10",
+        now=datetime(2026, 7, 30, 12, 0, 10),
+        force_emit=True,
+    ) == []
+
+    rules_state = next(
+        payload for event, payload in emitted if event == "alert_rules_updated"
+    )
+    assert rules_state["items"][0]["state"]["status"] == "watching"
+    assert rules_state["items"][0]["inspection"]["current_value"] == 700.0
+    assert {event for event, _payload in emitted} == {"alert_rules_updated"}
+
+
 def test_portfolio_runtime_builds_state_and_attaches_alert_status():
     from goldmonitor import portfolio as portfolio_core
     from goldmonitor.portfolio_runtime import PortfolioRuntime

--- a/tests/test_market_runtime_module.py
+++ b/tests/test_market_runtime_module.py
@@ -176,7 +176,9 @@ def test_market_runtime_updates_state_and_emits_price_status_and_history():
         format_price_title=lambda rmb, usd: f"{rmb}/{usd}",
         update_desktop_price_title=lambda title: None,
         update_floating_price=lambda rmb, usd, pct: None,
-        check_alert_rules=lambda now_str, now=None: alerts.append((now_str, now)),
+        check_alert_rules=lambda now_str, now=None, force_emit=False: alerts.append(
+            (now_str, now, force_emit)
+        ),
         now_factory=lambda: datetime(2026, 7, 28, 12, 0, 0),
         ounce_to_gram=31.1035,
     )
@@ -189,6 +191,7 @@ def test_market_runtime_updates_state_and_emits_price_status_and_history():
     assert len(state["price_history"]) == 1
     assert archived == state["price_history"]
     assert alerts[0][0] == "12:00:00"
+    assert alerts[0][2] is True
     assert [event for event, _payload in emitted] == [
         "price_update",
         "fetch_status",
@@ -196,6 +199,9 @@ def test_market_runtime_updates_state_and_emits_price_status_and_history():
     ]
     assert emitted[0][1]["source_comparison"] == {"status": "ok"}
     assert emitted[-1][1]["scope"] == "live"
+
+    assert runtime.fetch_once() is True
+    assert alerts[1][2] is False
 
 
 def test_market_runtime_state_helpers_roundtrip_explicit_fields():


### PR DESCRIPTION
## 问题

应用重新启动后，预警中心会先在当前行情尚未返回时显示“等待数据”。首轮行情到达后，如果规则持久化状态原本已经是“监控中”，后端判断规则内容没有变化，便不会重新推送运行视图，导致页面持续显示旧状态，直到用户编辑保存或切换启停。

## 修复

- 当美元或人民币价格首次从不可用变为可用时，强制推送一次最新预警规则状态。
- 保持后续常规行情刷新逻辑不变，避免每 10 秒重复重绘预警页面。
- 扩展行情与预警运行时接口，传递首轮数据就绪标记。
- 增加应用重启场景和只刷新一次的回归测试。

## 用户影响

- 应用刚启动且行情未返回时仍可短暂显示“等待数据”。
- 首轮行情成功返回后自动变为“监控中”，无需编辑、保存或切换启停。
- 现有规则配置、本地数据和通知逻辑无需迁移。

## 验证

- `.venv/bin/python scripts/run_checks.py`：429 项测试通过。
- 隔离网页验收：初始显示“等待数据”，首轮行情到达后自动显示“监控中”。
- 预警汇总计数同步从 0 更新为 1，浏览器控制台无错误。
- `git diff --check`：通过。
