### PR TITLE
feat: 增加历史模拟数据质量评估

### DIFF
--- a/goldmonitor/portfolio_investment.py
+++ b/goldmonitor/portfolio_investment.py
@@ -1175,6 +1175,175 @@ def _simulation_interval_label(seconds):
     return f"约 {max(1, round(seconds / 86400))} 天"
 
 
+def _simulation_granularity(interval_seconds):
+    if not interval_seconds:
+        return {"key": "unknown", "label": "无法判断"}
+    if interval_seconds <= 15 * 60:
+        return {"key": "fine", "label": "分钟级"}
+    if interval_seconds <= 2 * 60 * 60:
+        return {"key": "hourly", "label": "小时级"}
+    if interval_seconds <= 36 * 60 * 60:
+        return {"key": "daily", "label": "日级"}
+    return {"key": "sparse", "label": "稀疏样本"}
+
+
+def _simulation_gap_items(points, start_at, end_at, interval_seconds):
+    if not interval_seconds or end_at <= start_at:
+        return []
+    threshold_seconds = interval_seconds * 1.5
+    boundaries = [(start_at, None), *points, (end_at, None)]
+    gaps = []
+    for index, (previous, current) in enumerate(zip(boundaries, boundaries[1:])):
+        gap_seconds = int((current[0] - previous[0]).total_seconds())
+        if gap_seconds <= threshold_seconds:
+            continue
+        if index == 0:
+            estimated_missing = max(1, math.floor(gap_seconds / interval_seconds))
+            position = "leading"
+        elif index == len(boundaries) - 2:
+            estimated_missing = max(1, math.floor(gap_seconds / interval_seconds))
+            position = "trailing"
+        else:
+            estimated_missing = max(
+                1,
+                math.floor(gap_seconds / interval_seconds) - 1,
+            )
+            position = "internal"
+        gaps.append({
+            "start_timestamp": previous[0].isoformat(timespec="seconds"),
+            "end_timestamp": current[0].isoformat(timespec="seconds"),
+            "duration_seconds": gap_seconds,
+            "estimated_missing_points": estimated_missing,
+            "position": position,
+        })
+    return gaps
+
+
+def _simulation_data_quality(points, start_at, end_at, interval_seconds):
+    window_points = [item for item in points if start_at <= item[0] <= end_at]
+    duration_seconds = max(1, int((end_at - start_at).total_seconds()))
+    expected_point_count = (
+        math.floor(duration_seconds / interval_seconds) + 1
+        if interval_seconds
+        else 0
+    )
+    point_count = len(window_points)
+    missing_point_count = (
+        max(0, expected_point_count - point_count)
+        if expected_point_count
+        else 0
+    )
+    density_percent = (
+        min(100.0, point_count / expected_point_count * 100)
+        if expected_point_count
+        else None
+    )
+    if window_points:
+        range_start = max(start_at, window_points[0][0])
+        range_end = min(end_at, window_points[-1][0])
+        range_coverage_percent = max(
+            0.0,
+            min(
+                100.0,
+                (range_end - range_start).total_seconds() / duration_seconds * 100,
+            ),
+        )
+    else:
+        range_coverage_percent = 0.0
+    gaps = _simulation_gap_items(
+        window_points,
+        start_at,
+        end_at,
+        interval_seconds,
+    )
+    return {
+        "requested_start_timestamp": start_at.isoformat(timespec="seconds"),
+        "requested_end_timestamp": end_at.isoformat(timespec="seconds"),
+        "point_count": point_count,
+        "expected_point_count": expected_point_count,
+        "missing_point_count": missing_point_count,
+        "density_percent": density_percent,
+        "range_coverage_percent": range_coverage_percent,
+        "gap_count": len(gaps),
+        "largest_gap_seconds": max(
+            (item["duration_seconds"] for item in gaps),
+            default=0,
+        ),
+        "gaps": sorted(
+            gaps,
+            key=lambda item: item["duration_seconds"],
+            reverse=True,
+        )[:5],
+        "granularity": _simulation_granularity(interval_seconds),
+    }
+
+
+def _simulation_confidence(
+    *,
+    scheduled_count,
+    covered_count,
+    latest_price,
+    data_quality,
+):
+    if not scheduled_count:
+        return {
+            "level": "unavailable",
+            "label": "无法评估",
+            "score": None,
+            "summary": "所选窗口内没有计划期次，无法评估模拟结果可信度。",
+            "reasons": ["调整模拟范围，或检查计划的开始日期和执行频率。"],
+        }
+
+    covered_percent = covered_count / scheduled_count * 100
+    range_percent = float(data_quality.get("range_coverage_percent") or 0)
+    density_percent = float(data_quality.get("density_percent") or 0)
+    granularity_key = data_quality.get("granularity", {}).get("key")
+    granularity_score = {
+        "fine": 100,
+        "hourly": 90,
+        "daily": 65,
+        "sparse": 30,
+        "unknown": 0,
+    }.get(granularity_key, 0)
+    score = round(
+        covered_percent * 0.45
+        + range_percent * 0.20
+        + density_percent * 0.20
+        + granularity_score * 0.10
+        + (100 if latest_price is not None else 0) * 0.05
+    )
+    level = "high" if score >= 85 else "medium" if score >= 60 else "low"
+    label = {"high": "高", "medium": "中", "low": "低"}[level]
+    reasons = []
+    if covered_count < scheduled_count:
+        reasons.append(f"仅匹配 {covered_count}/{scheduled_count} 个计划期次。")
+    if range_percent < 90:
+        reasons.append(f"本地行情只覆盖所选时间范围的 {range_percent:.0f}%。")
+    if density_percent < 80:
+        reasons.append(f"按当前粒度估算，样本完整度为 {density_percent:.0f}%。")
+    if granularity_key in {"daily", "sparse", "unknown"}:
+        reasons.append(
+            "样本粒度较粗，期次成交价可能与真实时点存在偏差。"
+            if granularity_key != "unknown"
+            else "样本不足，无法判断时间粒度。"
+        )
+    if latest_price is None:
+        reasons.append("范围末端没有邻近行情，无法估算当前市值。")
+    if not reasons:
+        reasons.append("计划期次、时间范围和末端估值均有连续行情支持。")
+    return {
+        "level": level,
+        "label": label,
+        "score": score,
+        "summary": {
+            "high": "历史样本对当前模拟提供了较完整的支持。",
+            "medium": "模拟结果可用于趋势参考，但仍存在数据覆盖限制。",
+            "low": "历史样本不足，结果只适合了解大致方向。",
+        }[level],
+        "reasons": reasons[:4],
+    }
+
+
 def _nearest_simulation_point(points, timestamps, target, tolerance_seconds):
     if not points:
         return None
@@ -1337,6 +1506,18 @@ def investment_plan_history_simulation(plan, price_history, *, days=30, now=None
     scheduled_count = len(executions)
     missing_count = scheduled_count - covered_count
     point_count = len(eligible_points)
+    data_quality = _simulation_data_quality(
+        points,
+        start_at,
+        now,
+        interval_seconds,
+    )
+    confidence = _simulation_confidence(
+        scheduled_count=scheduled_count,
+        covered_count=covered_count,
+        latest_price=latest_price,
+        data_quality=data_quality,
+    )
     return {
         "days": window_days,
         "supported": True,
@@ -1385,7 +1566,9 @@ def investment_plan_history_simulation(plan, price_history, *, days=30, now=None
             "covered_percent": (
                 covered_count / scheduled_count * 100 if scheduled_count else None
             ),
+            "data_quality": data_quality,
         },
+        "confidence": confidence,
         "executions": executions,
     }
 

--- a/static/app.css
+++ b/static/app.css
@@ -1031,10 +1031,31 @@
   .portfolio-investment-simulation-loading, .portfolio-investment-simulation-error, .portfolio-investment-simulation-empty { padding:9px; border-left:2px solid rgba(255,255,255,0.12); color:var(--text-dim); background:rgba(255,255,255,0.018); font-size:0.58rem; line-height:1.45; }
   .portfolio-investment-simulation-error { border-left-color:var(--up); color:#e3b1b1; }
   .portfolio-investment-simulation-result { display:grid; gap:8px; min-width:0; }
+  .portfolio-investment-simulation-confidence { display:grid; grid-template-columns:104px minmax(0, 1fr); min-width:0; overflow:hidden; border:1px solid rgba(255,255,255,0.065); border-radius:7px; background:rgba(255,255,255,0.018); }
+  .portfolio-investment-simulation-confidence-score { display:flex; min-width:0; padding:9px 10px; flex-direction:column; justify-content:center; border-right:1px solid rgba(255,255,255,0.06); box-shadow:inset 3px 0 0 var(--text-dim); }
+  .portfolio-investment-simulation-confidence.high .portfolio-investment-simulation-confidence-score { box-shadow:inset 3px 0 0 var(--down); }
+  .portfolio-investment-simulation-confidence.medium .portfolio-investment-simulation-confidence-score { box-shadow:inset 3px 0 0 var(--gold); }
+  .portfolio-investment-simulation-confidence.low .portfolio-investment-simulation-confidence-score { box-shadow:inset 3px 0 0 var(--up); }
+  .portfolio-investment-simulation-confidence-score span, .portfolio-investment-simulation-confidence-score strong, .portfolio-investment-simulation-confidence-score small { display:block; }
+  .portfolio-investment-simulation-confidence-score span, .portfolio-investment-simulation-confidence-score small { color:var(--text-dim); font-size:0.52rem; }
+  .portfolio-investment-simulation-confidence-score strong { margin:2px 0; color:#ececf1; font-size:1rem; line-height:1; }
+  .portfolio-investment-simulation-confidence.high .portfolio-investment-simulation-confidence-score strong { color:var(--down); }
+  .portfolio-investment-simulation-confidence.medium .portfolio-investment-simulation-confidence-score strong { color:var(--gold); }
+  .portfolio-investment-simulation-confidence.low .portfolio-investment-simulation-confidence-score strong { color:#e7a1a1; }
+  .portfolio-investment-simulation-confidence-body { min-width:0; padding:8px 10px; }
+  .portfolio-investment-simulation-confidence-body > strong { display:block; color:#dcdce4; font-size:0.58rem; line-height:1.4; }
+  .portfolio-investment-simulation-quality-facts { display:flex; margin-top:5px; flex-wrap:wrap; gap:4px 10px; color:var(--text-dim); font-family:"SF Mono","JetBrains Mono","Consolas",monospace; font-size:0.5rem; }
+  .portfolio-investment-simulation-quality-facts span { position:relative; white-space:nowrap; }
+  .portfolio-investment-simulation-quality-facts span + span::before { position:absolute; left:-6px; color:rgba(255,255,255,0.18); content:"/"; }
+  .portfolio-investment-simulation-confidence-body ul { display:grid; gap:2px; margin:6px 0 0; padding:0; color:var(--text-dim); font-size:0.52rem; line-height:1.35; list-style:none; }
+  .portfolio-investment-simulation-confidence-body li { position:relative; padding-left:9px; overflow-wrap:anywhere; }
+  .portfolio-investment-simulation-confidence-body li::before { position:absolute; top:0.43em; left:0; width:3px; height:3px; border-radius:50%; background:rgba(255,255,255,0.28); content:""; }
   .portfolio-investment-simulation-coverage { display:grid; grid-template-columns:repeat(2, minmax(0, 1fr)); min-width:0; overflow:hidden; border-top:1px solid rgba(255,255,255,0.06); border-bottom:1px solid rgba(255,255,255,0.06); }
   .portfolio-investment-simulation-coverage > div { min-width:0; padding:8px; border-left:1px solid rgba(255,255,255,0.055); }
   .portfolio-investment-simulation-coverage > div:first-child { border-left:0; }
-  .portfolio-investment-simulation-coverage > div:nth-child(3) { grid-column:1 / -1; border-top:1px solid rgba(255,255,255,0.055); border-left:0; }
+  .portfolio-investment-simulation-coverage > div:nth-child(odd) { border-left:0; }
+  .portfolio-investment-simulation-coverage > div:nth-child(n + 3) { border-top:1px solid rgba(255,255,255,0.055); }
+  .portfolio-investment-simulation-coverage > div:nth-child(5) { grid-column:1 / -1; }
   .portfolio-investment-simulation-coverage span, .portfolio-investment-simulation-coverage strong, .portfolio-investment-simulation-coverage small { display:block; min-width:0; }
   .portfolio-investment-simulation-coverage span, .portfolio-investment-simulation-coverage small { color:var(--text-dim); font-size:0.55rem; }
   .portfolio-investment-simulation-coverage strong { margin:3px 0; color:#e8e8ec; font-family:"SF Mono","JetBrains Mono","Consolas",monospace; font-size:0.66rem; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
@@ -1042,6 +1063,16 @@
   .portfolio-investment-simulation-coverage strong.partial { color:var(--gold); }
   .portfolio-investment-simulation-coverage strong.missing { color:var(--up); }
   .portfolio-investment-simulation-coverage strong.empty { color:var(--text-dim); }
+  .portfolio-investment-simulation-gaps { min-width:0; border-top:1px dashed rgba(255,255,255,0.06); }
+  .portfolio-investment-simulation-gaps summary { padding-top:7px; color:var(--text-dim); cursor:pointer; font-size:0.55rem; }
+  .portfolio-investment-simulation-gaps > div { display:grid; max-height:150px; margin-top:6px; overflow-y:auto; }
+  .portfolio-investment-simulation-gaps > div > div { display:grid; grid-template-columns:minmax(0, 1fr) auto; gap:12px; min-width:0; padding:7px 8px; border-top:1px solid rgba(255,255,255,0.045); border-left:2px solid rgba(221,170,78,0.48); }
+  .portfolio-investment-simulation-gaps > div > div:first-child { border-top:0; }
+  .portfolio-investment-simulation-gaps span { min-width:0; }
+  .portfolio-investment-simulation-gaps span:last-child { text-align:right; }
+  .portfolio-investment-simulation-gaps strong, .portfolio-investment-simulation-gaps small { display:block; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .portfolio-investment-simulation-gaps strong { color:#dcdce4; font-size:0.56rem; }
+  .portfolio-investment-simulation-gaps small { margin-top:2px; color:var(--text-dim); font-size:0.5rem; }
   .portfolio-investment-simulation-metrics { display:grid; grid-template-columns:repeat(2, minmax(0, 1fr)); min-width:0; }
   .portfolio-investment-simulation-metrics > div { min-width:0; padding:4px 8px; border-left:1px solid rgba(255,255,255,0.055); }
   .portfolio-investment-simulation-metrics > div:first-child { border-left:0; }
@@ -1677,10 +1708,14 @@
     .portfolio-investment-simulation-controls { width:100%; }
     .portfolio-investment-simulation-controls label { flex:1; }
     .portfolio-investment-simulation-controls select { width:100%; }
+    .portfolio-investment-simulation-confidence { grid-template-columns:1fr; }
+    .portfolio-investment-simulation-confidence-score { border-right:0; border-bottom:1px solid rgba(255,255,255,0.06); }
     .portfolio-investment-simulation-coverage, .portfolio-investment-simulation-metrics { grid-template-columns:1fr; }
     .portfolio-investment-simulation-coverage > div, .portfolio-investment-simulation-metrics > div { border-left:0; border-top:1px solid rgba(255,255,255,0.055); }
     .portfolio-investment-simulation-coverage > div:first-child, .portfolio-investment-simulation-metrics > div:first-child { border-top:0; }
-    .portfolio-investment-simulation-coverage > div:nth-child(3) { grid-column:auto; }
+    .portfolio-investment-simulation-coverage > div:nth-child(5) { grid-column:auto; }
+    .portfolio-investment-simulation-gaps > div > div { grid-template-columns:1fr; gap:5px; }
+    .portfolio-investment-simulation-gaps span:last-child { text-align:left; }
     .portfolio-investment-simulation-runs > div > div { grid-template-columns:1fr; gap:5px; }
     .portfolio-investment-simulation-runs span:last-child { text-align:left; }
     .portfolio-investment-commitment-section-head { align-items:flex-start; flex-direction:column; }

--- a/static/portfolio-investment-simulation.js
+++ b/static/portfolio-investment-simulation.js
@@ -76,6 +76,66 @@ function portfolioInvestmentSimulationCoverageLabel(result) {
   return { text: '完整覆盖', tone: 'complete' };
 }
 
+function portfolioInvestmentSimulationDuration(seconds) {
+  const value = Math.max(0, Number(seconds) || 0);
+  if (!value) return '无明显缺口';
+  if (value < 3600) return Math.max(1, Math.round(value / 60)) + ' 分钟';
+  if (value < 86400) return Math.max(1, Math.round(value / 3600)) + ' 小时';
+  return Math.max(1, Math.round(value / 86400)) + ' 天';
+}
+
+function portfolioInvestmentSimulationConfidenceMarkup(result) {
+  const confidence = result && result.confidence && typeof result.confidence === 'object'
+    ? result.confidence
+    : {};
+  const quality = result && result.coverage && result.coverage.data_quality && typeof result.coverage.data_quality === 'object'
+    ? result.coverage.data_quality
+    : {};
+  const granularity = quality.granularity && typeof quality.granularity === 'object'
+    ? quality.granularity
+    : {};
+  const reasons = Array.isArray(confidence.reasons) ? confidence.reasons : [];
+  const score = Number.isFinite(Number(confidence.score)) ? Math.max(0, Math.min(100, Number(confidence.score))) : null;
+  const density = Number.isFinite(Number(quality.density_percent)) ? Number(quality.density_percent).toFixed(0) + '%' : '--';
+  const range = Number.isFinite(Number(quality.range_coverage_percent)) ? Number(quality.range_coverage_percent).toFixed(0) + '%' : '--';
+  const level = ['high', 'medium', 'low', 'unavailable'].includes(confidence.level) ? confidence.level : 'unavailable';
+  return [
+    '<section class="portfolio-investment-simulation-confidence ' + level + '">',
+    '<div class="portfolio-investment-simulation-confidence-score"><span>结果可信度</span><strong>' + escapeHtml(confidence.label || '无法评估') + '</strong><small>' + escapeHtml(score == null ? '暂无评分' : score.toFixed(0) + ' / 100') + '</small></div>',
+    '<div class="portfolio-investment-simulation-confidence-body"><strong>' + escapeHtml(confidence.summary || '历史数据质量信息不足。') + '</strong><div class="portfolio-investment-simulation-quality-facts">',
+    '<span>范围 ' + escapeHtml(range) + '</span>',
+    '<span>完整度 ' + escapeHtml(density) + '</span>',
+    '<span>' + escapeHtml(granularity.label || '无法判断粒度') + '</span>',
+    '<span>' + escapeHtml(String(Math.max(0, Number(quality.gap_count) || 0)) + ' 个缺口') + '</span>',
+    '</div>',
+    reasons.length ? '<ul>' + reasons.map(reason => '<li>' + escapeHtml(reason) + '</li>').join('') + '</ul>' : '',
+    '</div>',
+    '</section>',
+  ].join('');
+}
+
+function portfolioInvestmentSimulationGapMarkup(result) {
+  const quality = result && result.coverage && result.coverage.data_quality && typeof result.coverage.data_quality === 'object'
+    ? result.coverage.data_quality
+    : {};
+  const gaps = Array.isArray(quality.gaps) ? quality.gaps : [];
+  if (!gaps.length) return '';
+  const positionLabel = { leading: '窗口开头', internal: '窗口中段', trailing: '窗口末端' };
+  return [
+    '<details class="portfolio-investment-simulation-gaps">',
+    '<summary>查看 ' + escapeHtml(String(gaps.length)) + ' 个主要行情缺口</summary>',
+    '<div>',
+    gaps.map(item => [
+      '<div>',
+      '<span><strong>' + escapeHtml(positionLabel[item.position] || '时间区间') + '</strong><small>' + escapeHtml(portfolioInvestmentDateTime(item.start_timestamp) + ' 至 ' + portfolioInvestmentDateTime(item.end_timestamp)) + '</small></span>',
+      '<span><strong>' + escapeHtml(portfolioInvestmentSimulationDuration(item.duration_seconds)) + '</strong><small>估算缺失 ' + escapeHtml(String(Math.max(0, Number(item.estimated_missing_points) || 0))) + ' 个样本</small></span>',
+      '</div>',
+    ].join('')).join(''),
+    '</div>',
+    '</details>',
+  ].join('');
+}
+
 function portfolioInvestmentSimulationExecutionMarkup(result) {
   const executions = Array.isArray(result && result.executions) ? result.executions : [];
   if (!executions.length) return '<div class="portfolio-investment-simulation-empty">所选范围内没有计划期次。</div>';
@@ -111,13 +171,24 @@ function portfolioInvestmentSimulationResultMarkup(result) {
   const valuationText = result.latest_price == null
     ? '范围末端无邻近行情，未估算市值'
     : '末端样本 ' + portfolioInvestmentDateTime(result.latest_price_timestamp);
+  const qualityData = coverageData.data_quality && typeof coverageData.data_quality === 'object' ? coverageData.data_quality : {};
+  const qualityRangeText = qualityData.requested_start_timestamp
+    ? portfolioInvestmentDateTime(qualityData.requested_start_timestamp)
+    : '--';
+  const qualityRangeEndText = qualityData.requested_end_timestamp
+    ? '至 ' + portfolioInvestmentDateTime(qualityData.requested_end_timestamp)
+    : '没有请求范围';
   return [
     '<div class="portfolio-investment-simulation-result">',
+    portfolioInvestmentSimulationConfidenceMarkup(result),
     '<div class="portfolio-investment-simulation-coverage">',
     '<div><span>行情覆盖</span><strong class="' + coverage.tone + '">' + escapeHtml(coverage.text) + '</strong><small>' + escapeHtml(scheduled ? covered + '/' + scheduled + ' 期 · ' + (coveredPercent == null ? '--' : coveredPercent.toFixed(0) + '%') : '当前计划在窗口内未产生期次') + '</small></div>',
     '<div><span>本地样本</span><strong>' + escapeHtml(String(Number(coverageData.point_count) || 0) + ' 个') + '</strong><small>' + escapeHtml(coverageData.interval_label || '样本不足') + '</small></div>',
     '<div><span>数据区间</span><strong>' + escapeHtml(coverageData.first_timestamp ? portfolioInvestmentDateTime(coverageData.first_timestamp) : '--') + '</strong><small>' + escapeHtml(coverageData.last_timestamp ? '至 ' + portfolioInvestmentDateTime(coverageData.last_timestamp) : '没有可用历史行情') + '</small></div>',
+    '<div><span>请求范围</span><strong>' + escapeHtml(qualityRangeText) + '</strong><small>' + escapeHtml(qualityRangeEndText) + '</small></div>',
+    '<div><span>最大缺口</span><strong>' + escapeHtml(portfolioInvestmentSimulationDuration(qualityData.largest_gap_seconds)) + '</strong><small>' + escapeHtml((Number(qualityData.gap_count) || 0) ? String(Number(qualityData.gap_count) || 0) + ' 个明显缺口' : '当前粒度下未发现明显缺口') + '</small></div>',
     '</div>',
+    portfolioInvestmentSimulationGapMarkup(result),
     result.usable ? [
       '<div class="portfolio-investment-simulation-metrics">',
       '<div><span>计划买入</span><strong>' + escapeHtml(formatPortfolioMoney(result.planned_amount, result.mode)) + '</strong><small>已覆盖支出 ' + escapeHtml(formatPortfolioMoney(result.actual_cost, result.mode)) + '</small></div>',

--- a/tests/test_portfolio_investment_app.py
+++ b/tests/test_portfolio_investment_app.py
@@ -490,6 +490,9 @@ def test_app_simulates_investment_plan_history_with_request_id(monkeypatch, tmp_
     assert simulated["request_id"] == "simulation-1"
     assert simulated["result"]["covered_count"] == 2
     assert simulated["result"]["latest_price"] == 520.0
+    assert simulated["result"]["coverage"]["data_quality"]["point_count"] == 3
+    assert simulated["result"]["coverage"]["data_quality"]["granularity"]["key"] == "daily"
+    assert simulated["result"]["confidence"]["level"] == "medium"
     assert app.portfolio_transactions == []
     client.disconnect()
 

--- a/tests/test_portfolio_investment_frontend.py
+++ b/tests/test_portfolio_investment_frontend.py
@@ -122,7 +122,8 @@ vm.runInContext(`applyPortfolioInvestmentSimulation({id:'plan-1',request_id:'1',
   days:90,usable:true,partial:true,mode:'rmb',scheduled_count:3,covered_count:2,missing_count:1,
   actual_cost:2002,total_fees:2,quantity:4,average_price:500,latest_price:510,
   latest_price_timestamp:'2026-08-12T10:00:00',market_value:2040,pnl:38,pnl_percent:1.898,
-  coverage:{point_count:44,first_timestamp:'2026-07-01T09:00:00',last_timestamp:'2026-08-12T10:00:00',interval_label:'约 1 天'},
+  confidence:{level:'medium',label:'中',score:72,summary:'模拟结果可用于趋势参考，但仍存在数据覆盖限制。',reasons:['仅匹配 2/3 个计划期次。','样本粒度较粗，期次成交价可能与真实时点存在偏差。']},
+  coverage:{point_count:44,first_timestamp:'2026-07-01T09:00:00',last_timestamp:'2026-08-12T10:00:00',interval_label:'约 1 天',data_quality:{requested_start_timestamp:'2026-05-15T00:00:00',requested_end_timestamp:'2026-08-12T10:00:00',density_percent:78,range_coverage_percent:64,gap_count:3,largest_gap_seconds:259200,granularity:{key:'daily',label:'日级'},gaps:[{start_timestamp:'2026-05-15T00:00:00',end_timestamp:'2026-05-18T00:00:00',duration_seconds:259200,estimated_missing_points:3,position:'leading'}]}},
   executions:[
     {scheduled_at:'2026-07-01T09:00:00',status:'estimated',sample_timestamp:'2026-07-01T09:00:00',price:500,quantity:2,total_cost:1001},
     {scheduled_at:'2026-08-01T09:00:00',status:'missing'}
@@ -131,6 +132,10 @@ vm.runInContext(`applyPortfolioInvestmentSimulation({id:'plan-1',request_id:'1',
 const html = vm.runInContext("portfolioInvestmentSimulationMarkup({id:'plan-1'})", context);
 if (!html.includes('近 90 天') || !html.includes('部分覆盖') || !html.includes('2/3 期 · 67%')) throw new Error('simulation must render selected range and partial coverage');
 if (!html.includes('44 个') || !html.includes('约 1 天') || !html.includes('附近没有可用行情样本')) throw new Error('simulation must render data coverage and missing run');
+if (!html.includes('结果可信度') || !html.includes('72 / 100') || !html.includes('范围 64%') || !html.includes('完整度 78%')) throw new Error('simulation must render confidence score and quality facts');
+if (!html.includes('日级') || !html.includes('3 个缺口') || !html.includes('最大缺口') || !html.includes('3 天')) throw new Error('simulation must render granularity and gap summary');
+if (!html.includes('查看 1 个主要行情缺口') || !html.includes('窗口开头') || !html.includes('估算缺失 3 个样本')) throw new Error('simulation must render major gap detail');
+if (!html.includes('仅匹配 2/3 个计划期次') || !html.includes('成交价可能与真实时点存在偏差')) throw new Error('simulation must explain confidence limitations');
 if (!html.includes('基于本地历史样本估算') || !html.includes('不代表真实成交、滑点或历史真实收益') || !html.includes('不会写入持仓和流水')) throw new Error('simulation must explain estimation limits');
 vm.runInContext("setPortfolioInvestmentSimulationDays('plan-1', 7)", context);
 if (context.portfolioInvestmentSimulations['plan-1'].result !== null) throw new Error('changing range must clear the previous result');

--- a/tests/test_portfolio_investment_module.py
+++ b/tests/test_portfolio_investment_module.py
@@ -1390,11 +1390,134 @@ def test_investment_history_simulation_reports_partial_and_missing_coverage():
     assert partial["missing_count"] == 1
     assert partial["coverage"]["interval_seconds"] == 3600
     assert partial["coverage"]["interval_label"] == "约 1 小时"
+    assert partial["coverage"]["data_quality"]["granularity"] == {
+        "key": "hourly",
+        "label": "小时级",
+    }
+    assert partial["coverage"]["data_quality"]["gap_count"] >= 2
+    assert partial["confidence"]["level"] == "medium"
+    assert partial["confidence"]["score"] >= 60
+    assert any("计划期次" in reason for reason in partial["confidence"]["reasons"])
     assert missing["usable"] is False
     assert missing["partial"] is True
     assert missing["covered_count"] == 0
     assert missing["actual_cost"] == 0
     assert missing["market_value"] is None
+    assert missing["coverage"]["data_quality"]["point_count"] == 0
+    assert missing["coverage"]["data_quality"]["range_coverage_percent"] == 0
+    assert missing["confidence"]["level"] == "low"
+
+
+def test_investment_history_simulation_reports_continuous_quality_and_high_confidence():
+    from goldmonitor.portfolio_investment import investment_plan_history_simulation
+
+    now = datetime(2026, 8, 12, 10, 0)
+    start_at = datetime(2026, 8, 6, 0, 0)
+    history = []
+    cursor = start_at
+    while cursor <= now:
+        history.append({"timestamp": cursor.isoformat(), "rmb": 500})
+        cursor += timedelta(hours=1)
+    plan = {
+        "id": "plan-quality-high",
+        "mode": "rmb",
+        "amount": 1000,
+        "fee": 0,
+        "frequency": "daily",
+        "time": "09:00",
+        "month": 1,
+        "day": 1,
+        "weekday": 1,
+        "start_date": "2026-08-06",
+        "end_date": "",
+        "created_at": "2026-08-01T08:00:00",
+    }
+
+    result = investment_plan_history_simulation(plan, history, days=7, now=now)
+    quality = result["coverage"]["data_quality"]
+
+    assert quality["requested_start_timestamp"] == "2026-08-06T00:00:00"
+    assert quality["requested_end_timestamp"] == "2026-08-12T10:00:00"
+    assert quality["point_count"] == quality["expected_point_count"]
+    assert quality["missing_point_count"] == 0
+    assert quality["density_percent"] == 100
+    assert quality["range_coverage_percent"] == 100
+    assert quality["gap_count"] == 0
+    assert quality["largest_gap_seconds"] == 0
+    assert quality["gaps"] == []
+    assert result["confidence"]["level"] == "high"
+    assert result["confidence"]["score"] >= 95
+    assert result["confidence"]["reasons"] == [
+        "计划期次、时间范围和末端估值均有连续行情支持。"
+    ]
+
+
+def test_investment_history_simulation_reports_largest_internal_gap():
+    from goldmonitor.portfolio_investment import investment_plan_history_simulation
+
+    now = datetime(2026, 8, 12, 10, 0)
+    history = []
+    cursor = datetime(2026, 8, 6, 0, 0)
+    while cursor <= now:
+        if not datetime(2026, 8, 9, 0, 0) <= cursor <= datetime(2026, 8, 9, 6, 0):
+            history.append({"timestamp": cursor.isoformat(), "rmb": 500})
+        cursor += timedelta(hours=1)
+    plan = {
+        "id": "plan-quality-gap",
+        "mode": "rmb",
+        "amount": 1000,
+        "fee": 0,
+        "frequency": "daily",
+        "time": "09:00",
+        "month": 1,
+        "day": 1,
+        "weekday": 1,
+        "start_date": "2026-08-06",
+        "end_date": "",
+        "created_at": "2026-08-01T08:00:00",
+    }
+
+    result = investment_plan_history_simulation(plan, history, days=7, now=now)
+    quality = result["coverage"]["data_quality"]
+
+    assert quality["gap_count"] == 1
+    assert quality["largest_gap_seconds"] == 8 * 60 * 60
+    assert quality["gaps"][0] == {
+        "start_timestamp": "2026-08-08T23:00:00",
+        "end_timestamp": "2026-08-09T07:00:00",
+        "duration_seconds": 8 * 60 * 60,
+        "estimated_missing_points": 7,
+        "position": "internal",
+    }
+    assert quality["missing_point_count"] == 7
+
+
+def test_investment_history_simulation_confidence_is_unavailable_without_runs():
+    from goldmonitor.portfolio_investment import investment_plan_history_simulation
+
+    result = investment_plan_history_simulation(
+        {
+            "id": "plan-quality-no-runs",
+            "mode": "rmb",
+            "amount": 1000,
+            "fee": 0,
+            "frequency": "monthly",
+            "time": "09:00",
+            "month": 1,
+            "day": 1,
+            "weekday": 1,
+            "start_date": "2026-09-01",
+            "end_date": "",
+            "created_at": "2026-08-01T08:00:00",
+        },
+        [{"timestamp": "2026-08-12T10:00:00", "rmb": 500}],
+        days=7,
+        now=datetime(2026, 8, 12, 10, 0),
+    )
+
+    assert result["scheduled_count"] == 0
+    assert result["confidence"]["level"] == "unavailable"
+    assert result["confidence"]["score"] is None
 
 
 def test_investment_history_simulation_caps_sparse_sample_match_tolerance():


### PR DESCRIPTION
## 变更目标

让定投历史模拟明确说明本地行情是否足以支持结果，避免用户只看到盈亏数字而忽略样本范围、时间粒度和数据缺口。

## 变更内容

- 增加历史行情请求范围、理论样本数、样本完整度和范围覆盖率。
- 识别分钟级、小时级、日级和稀疏样本。
- 检测窗口开头、内部和末端缺口，展示最大缺口及主要缺口明细。
- 根据计划期次匹配、范围覆盖、样本完整度、时间粒度和末端估值生成可信度等级与评分。
- 为可信度降级提供可解释原因，不改变模拟计算、持仓和流水。
- 优化桌面端及移动端信息层级和响应式布局。

## 行为边界

- 数据质量分析只读取本地历史行情，不增加新的持久化数据。
- 历史模拟仍不会写入计划、持仓或流水。
- 可信度评分用于说明数据支持程度，不代表投资建议或真实历史收益。
- 本次不包含版本发布。

## 验证结果

- [x] 全量测试：591 passed
- [x] 定投模拟核心、Socket 接口和前端行为测试通过
- [x] 前端资源检查通过
- [x] 真实网页运行模拟与缺口展开交互通过
- [x] 1280px 无横向溢出
- [x] 480px 自动单列且无横向滚动
- [x] 浏览器控制台无错误或警告
- [x] 前端文本未使用 Emoji
