### PR TITLE
fix: 隔离配置导入后台线程测试

### DIFF
--- a/goldmonitor/socket_operations.py
+++ b/goldmonitor/socket_operations.py
@@ -195,7 +195,7 @@ def register_operations_handlers(
             "preferences": preferences,
             "message": "数据源配置已保存，将按新顺序刷新行情。",
         })
-        threading.Thread(target=fetch_price_once, daemon=True).start()
+        thread_factory(target=fetch_price_once, daemon=True).start()
 
 
     @socketio.on("reset_market_sources")
@@ -212,7 +212,7 @@ def register_operations_handlers(
             "preferences": preferences,
             "message": "已恢复默认数据源顺序。",
         })
-        threading.Thread(target=fetch_price_once, daemon=True).start()
+        thread_factory(target=fetch_price_once, daemon=True).start()
 
 
     @socketio.on("retry_market_source")
@@ -238,7 +238,7 @@ def register_operations_handlers(
             if isinstance(result.get("source_health"), dict):
                 socketio.emit("source_health_updated", result["source_health"])
 
-        threading.Thread(target=run_retry, daemon=True).start()
+        thread_factory(target=run_retry, daemon=True).start()
 
 
     @socketio.on("export_config")
@@ -372,7 +372,7 @@ def register_operations_handlers(
             emit("config_import_result", {**result, "message": "配置导入完成。"})
             if "settings" in result.get("imported", []):
                 socketio.emit("source_health_updated", get_source_health_state())
-                threading.Thread(target=fetch_price_once, daemon=True).start()
+                thread_factory(target=fetch_price_once, daemon=True).start()
         except (ValueError, json.JSONDecodeError) as exc:
             emit("config_import_result", {"ok": False, "message": str(exc)})
         except OSError:
@@ -385,7 +385,7 @@ def register_operations_handlers(
             result = reset_to_default_settings()
             emit("settings_reset_result", {**result, "message": "已恢复默认设置。"})
             socketio.emit("source_health_updated", get_source_health_state())
-            threading.Thread(target=fetch_price_once, daemon=True).start()
+            thread_factory(target=fetch_price_once, daemon=True).start()
         except OSError:
             emit("settings_reset_result", {"ok": False, "message": "恢复默认设置失败，请检查配置目录权限。"})
 

--- a/tests/test_config_import_app.py
+++ b/tests/test_config_import_app.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import sys
 from pathlib import Path
@@ -8,14 +9,52 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 
 @pytest.fixture(autouse=True)
-def _isolate_alert_rule_store(monkeypatch, tmp_path):
+def _isolate_config_import_runtime(monkeypatch, tmp_path):
     import app
 
+    class ImmediateThread:
+        def __init__(self, target, daemon=False):
+            self.target = target
+            self.daemon = daemon
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(app.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(app, "fetch_price_once", lambda: None)
     monkeypatch.setattr(app, "ALERT_RULES_PATH", str(tmp_path / "alert_rules.json"))
     monkeypatch.setattr(app, "alert_rules", [])
     monkeypatch.setattr(app, "alert_rule_migration_status", {"completed": True, "source_version": "1.0.7"})
     monkeypatch.setattr(app, "alert_rules_load_error", "")
     monkeypatch.setattr(app, "alert_rules_invalid_count", 0)
+
+
+def test_operations_handlers_only_create_threads_through_injected_factory():
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "goldmonitor"
+        / "socket_operations.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    direct_thread_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "threading"
+        and node.func.attr == "Thread"
+    ]
+    injected_thread_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "thread_factory"
+    ]
+
+    assert direct_thread_calls == []
+    assert len(injected_thread_calls) == 6
 
 
 def test_build_config_backup_exports_only_restorable_non_secret_settings(monkeypatch):


### PR DESCRIPTION
## 变更内容

- 将运维 Socket 处理器中的后台线程统一改为通过已注入的 `thread_factory` 创建。
- 配置导入测试使用同步受控线程和空行情刷新，不再遗留真实网络线程。
- 增加源码级约束，防止处理器再次绕过线程注入入口。

## 根因

配置导入包含设置时会启动行情刷新线程。测试结束后线程可能仍在运行，并在后续历史数据测试临时替换存储路径时完成写入，造成测试间状态污染和随机失败。

## 影响

生产行为保持异步不变；测试可控制线程执行时机，不再依赖网络速度和平台调度时序。

## 验证

- 配置导入与历史数据维护组合测试连续 10 轮通过，每轮 21 项。
- 项目全量检查通过，共 654 项测试通过。
- 全量 `pytest` 额外连续运行 5 轮，每轮 654 项通过。
